### PR TITLE
feat: tests for timeout logic and reopening ICA channel

### DIFF
--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -143,9 +143,6 @@ export class CosmosWrapper {
       gas_limit: Long.fromString('2000000'),
       amount: [{ denom: this.denom, amount: '10000' }],
     });
-    if (res.tx_response.code !== 0) {
-      throw new Error(res.tx_response.raw_log);
-    }
     return res?.tx_response;
   }
 

--- a/src/testcases/interchaintx.test.ts
+++ b/src/testcases/interchaintx.test.ts
@@ -146,7 +146,7 @@ describe('Neutron / Interchain TXs', () => {
       expect(res1.data.delegation_responses).toEqual([
         {
           // FIXME: 'stake'
-          balance: { amount: '2000', denom: 'stake' },
+          balance: { amount: '2000', denom: cm2.denom },
           delegation: {
             delegator_address: icaAddress1,
             shares: '2000.000000000000000000',
@@ -340,8 +340,7 @@ describe('Neutron / Interchain TXs', () => {
       );
       expect(res1.data.delegation_responses).toEqual([
         {
-          // FIXME: 'stake'
-          balance: { amount: '1020', denom: 'stake' },
+          balance: { amount: '1020', denom: cm2.denom },
           delegation: {
             delegator_address: icaAddress1,
             shares: '1020.000000000000000000',

--- a/src/testcases/interchaintx.test.ts
+++ b/src/testcases/interchaintx.test.ts
@@ -145,7 +145,6 @@ describe('Neutron / Interchain TXs', () => {
       );
       expect(res1.data.delegation_responses).toEqual([
         {
-          // FIXME: 'stake'
           balance: { amount: '2000', denom: cm2.denom },
           delegation: {
             delegator_address: icaAddress1,


### PR DESCRIPTION
**Tasks**: 
* https://p2pvalidator.atlassian.net/jira/software/projects/LSC/boards/121?selectedIssue=LSC-152
* https://p2pvalidator.atlassian.net/jira/software/projects/LSC/boards/121?selectedIssue=LSC-129

What tests are implemented:
* custom timeout when submitting ICA tx;
* tests for reregistering ICA after it was closed by timeout.

**Test with**: 
* https://github.com/neutron-org/neutron-contracts/pull/20 
* https://github.com/neutron-org/neutron/pull/43