### PR TITLE
Feat: expose neutron logs in Docker

### DIFF
--- a/setup/node/start.sh
+++ b/setup/node/start.sh
@@ -9,4 +9,11 @@ GRPCWEB=9091
 
 echo "Starting $CHAINID in $CHAIN_DIR..."
 echo "Creating log file at $CHAIN_DIR/$CHAINID.log"
-$BINARY start --log_level debug --log_format json --home $CHAIN_DIR/$CHAINID --pruning=nothing --grpc.address="0.0.0.0:$GRPCPORT" --grpc-web.address="0.0.0.0:$GRPCWEB" --trace > $CHAIN_DIR/$CHAINID.log 2>&1
+$BINARY start                           \
+  --log_level debug                     \
+  --log_format json                     \
+  --home $CHAIN_DIR/$CHAINID            \
+  --pruning=nothing                     \
+  --grpc.address="0.0.0.0:$GRPCPORT"    \
+  --grpc-web.address="0.0.0.0:$GRPCWEB" \
+  --trace 2>&1 | tee $CHAIN_DIR/$CHAINID.log


### PR DESCRIPTION
This PR allows to read logs using `docker logs` while also leaving log file enabled.