### PR TITLE
printing versions of services after starting containers

### DIFF
--- a/setup/Makefile
+++ b/setup/Makefile
@@ -8,7 +8,7 @@ build-hermes:
 		@docker build -f dockerbuilds/Dockerfile.hermes -t hermes:1.0.0 .
 
 build-relayer:
-		docker build ../../neutron-query-relayer -f ../../neutron-query-relayer/Dockerfile -t neutron-org/neutron-query-relayer
+		cd ../../neutron-query-relayer/ && make build-docker
 
 build-all: build-gaia build-neutron build-hermes build-relayer
 

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -76,26 +76,38 @@ export const showVersions = () => {
     console.log('Cannot get versions since NO_DOCKER ENV provided');
     return;
   }
-  const servicesAndGetVersionCommands = [
-    [
-      'neutrond',
-      `cd setup && docker compose exec neutron-node sh -c "/go/bin/neutrond version version --long | grep '^commit\\|^version'"`,
-    ],
+  const servicesAndGetVersionCommandsText = [
     [
       'ICQ relayer',
       'cd setup && docker compose exec relayer neutron_query_relayer version',
     ],
-    [
-      'gaiad',
-      `cd setup && docker compose exec gaia-node sh -c "gaiad version --long 2>&1 | grep '^commit\\|^version'"`,
-    ],
     ['hermes', 'cd setup && docker compose exec hermes hermes version'],
     ['Integration tests', "git log -1 --format='%H'"],
   ];
-  for (const service of servicesAndGetVersionCommands) {
+  for (const service of servicesAndGetVersionCommandsText) {
     try {
       const version = execSync(service[1]).toString().trim();
       console.log(`${service[0]} version:\n${version}`);
+    } catch (err) {
+      console.log(`Cannot get ${service[0]} version:\n${err}`);
+    }
+  }
+  const servicesAndGetVersionCommandsJson = [
+    [
+      'neutrond',
+      'cd setup && docker compose exec neutron-node /go/bin/neutrond version --long -o json',
+    ],
+    [
+      'gaiad',
+      'cd setup && docker compose exec gaia-node gaiad version --long 2>&1 -o json',
+    ],
+  ];
+  for (const service of servicesAndGetVersionCommandsJson) {
+    try {
+      const versionLong = JSON.parse(execSync(service[1]).toString().trim());
+      console.log(
+        `${service[0]} version:\nversion: ${versionLong['version']}\ncommit: ${versionLong['commit']}`,
+      );
     } catch (err) {
       console.log(`Cannot get ${service[0]} version:\n${err}`);
     }

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -79,13 +79,16 @@ export const showVersions = () => {
   const servicesAndGetVersionCommands = [
     [
       'neutrond',
-      'cd setup && docker compose exec neutron-node /go/bin/neutrond version',
+      `cd setup && docker compose exec neutron-node sh -c "/go/bin/neutrond version version --long | grep '^commit\\|^version'"`,
     ],
     [
       'ICQ relayer',
       'cd setup && docker compose exec relayer neutron_query_relayer version',
     ],
-    ['gaiad', 'cd setup && docker compose exec gaia-node gaiad version 2>&1'],
+    [
+      'gaiad',
+      `cd setup && docker compose exec gaia-node sh -c "gaiad version --long 2>&1 | grep '^commit\\|^version'"`,
+    ],
     ['hermes', 'cd setup && docker compose exec hermes hermes version'],
     ['Integration tests', "git log -1 --format='%H'"],
   ];


### PR DESCRIPTION
1. After starting containers, test code request versions of the binaries inside the containers so we can be sure we're running the version we expect to run
2. Makefile fixed to pass the flags to neutron-query-relayer builder container