### PR TITLE
(NTRN-275) Feat: Testing denom checking in feerefunder

### DIFF
--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -463,3 +463,12 @@ export const getContractsHashes = async (): Promise<Record<string, string>> => {
 
 const getContractBinary = async (fileName: string): Promise<Buffer> =>
   fsPromise.readFile(path.resolve(CONTRACTS_PATH, fileName));
+
+export const getIBCDenom = (portName, channelName, denom: string): string => {
+  const uatomIBCHash = crypto
+    .createHash('sha256')
+    .update(`${portName}/${channelName}/${denom}`)
+    .digest('hex')
+    .toUpperCase();
+  return `ibc/${uatomIBCHash}`;
+};

--- a/src/testcases/simple.test.ts
+++ b/src/testcases/simple.test.ts
@@ -5,6 +5,7 @@ import {
   IBC_RELAYER_NEUTRON_ADDRESS,
   NEUTRON_DENOM,
   NeutronContract,
+  getIBCDenom,
 } from '../helpers/cosmos';
 import { getRemoteHeight, getWithAttempts, waitBlocks } from '../helpers/wait';
 import { TestStateLocalCosmosTestNet } from './common_localcosmosnet';
@@ -196,13 +197,17 @@ describe('Neutron / Simple', () => {
       });
     });
     describe('Fee in wrong denom', () => {
-      const uatomIBCDenom =
-        'ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2';
+      const portName = 'transfer';
+      const channelName = 'channel-0';
+      const uatomIBCDenom = getIBCDenom(portName, channelName, 'uatom');
+      expect(uatomIBCDenom).toEqual(
+        'ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2',
+      );
       test('transfer some atoms to contract', async () => {
         const uatomAmount = '1000';
         const res = await cm2.msgIBCTransfer(
-          'transfer',
-          'channel-0',
+          portName,
+          channelName,
           { denom: cm2.denom, amount: uatomAmount },
           contractAddress,
           { revision_number: 2, revision_height: 100000000 },
@@ -216,7 +221,7 @@ describe('Neutron / Simple', () => {
             ?.amount,
         ).toEqual(uatomAmount);
       });
-      test('try to set fee in atoms', async () => {
+      test('try to set fee in IBC transferred atoms', async () => {
         const res = await cm.executeContract(
           contractAddress,
           JSON.stringify({

--- a/src/testcases/simple.test.ts
+++ b/src/testcases/simple.test.ts
@@ -196,14 +196,14 @@ describe('Neutron / Simple', () => {
       });
     });
     describe('Fee in wrong denom', () => {
-      const uatom_ibc_denom =
+      const uatomIBCDenom =
         'ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2';
       test('transfer some atoms to contract', async () => {
-        const uatom_amount = '1000';
+        const uatomAmount = '1000';
         const res = await cm2.msgIBCTransfer(
           'transfer',
           'channel-0',
-          { denom: cm2.denom, amount: uatom_amount },
+          { denom: cm2.denom, amount: uatomAmount },
           contractAddress,
           { revision_number: 2, revision_height: 100000000 },
         );
@@ -212,16 +212,16 @@ describe('Neutron / Simple', () => {
         await waitBlocks(cm.sdk, 10);
         const balances = await cm.queryBalances(contractAddress);
         expect(
-          balances.balances.find((bal): boolean => bal.denom == uatom_ibc_denom)
+          balances.balances.find((bal): boolean => bal.denom == uatomIBCDenom)
             ?.amount,
-        ).toEqual(uatom_amount);
+        ).toEqual(uatomAmount);
       });
       test('try to set fee in atoms', async () => {
         const res = await cm.executeContract(
           contractAddress,
           JSON.stringify({
             set_fees: {
-              denom: uatom_ibc_denom,
+              denom: uatomIBCDenom,
               ack_fee: '100',
               recv_fee: '0',
               timeout_fee: '100',

--- a/src/testcases/simple.test.ts
+++ b/src/testcases/simple.test.ts
@@ -221,8 +221,8 @@ describe('Neutron / Simple', () => {
           JSON.stringify({
             set_fees: {
               denom: uatom_ibc_denom,
-              ack_fee: '0',
-              recv_fee: '100',
+              ack_fee: '100',
+              recv_fee: '0',
               timeout_fee: '100',
             },
           }),
@@ -241,7 +241,7 @@ describe('Neutron / Simple', () => {
               },
             }),
           ),
-        ).rejects.toThrow(/invalid coins/);
+        ).rejects.toThrow(/insufficient fee/);
       });
     });
     describe('Not enough amount of tokens on contract to pay fee', () => {


### PR DESCRIPTION
This PR adds really basic test for changes made in [this fix of Neutron code](https://github.com/neutron-org/neutron/pull/98)

The aim is to check if there is no ability to pay fees in denom that is not registered in MinFees parameter of the chain.

Ideally, this PR should be checked in a way where this test is run with main (`neutron_audit_oak_19_09_2022_fixes` atm) branch of Neutron first to ensure it fails and with `fix/fees-check-bypass` after that to ensure it passes.