### PR TITLE
(NTRN-275) feat: failures query limitation test

### DIFF
--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -53,6 +53,14 @@ type Balance = {
   amount: string;
 };
 
+// PageRequest is the params of pagination for request
+export type PageRequest = {
+  'pagination.key'?: string;
+  'pagination.offset'?: string;
+  'pagination.limit'?: string;
+  'pagination.count_total'?: boolean;
+};
+
 // AckFailuresResponse is the response model for the contractmanager failures.
 export type AckFailuresResponse = {
   failures: Failure[];
@@ -320,12 +328,22 @@ export class CosmosWrapper {
     return balances.data as BalancesResponse;
   }
 
-  async queryAckFailures(addr: string): Promise<AckFailuresResponse> {
-    const req = await axios.get<AckFailuresResponse>(
-      `${this.sdk.url}/neutron/contractmanager/failures/${addr}`,
-    );
-
-    return req.data;
+  async queryAckFailures(
+    addr: string,
+    pagination?: PageRequest,
+  ): Promise<AckFailuresResponse> {
+    try {
+      const req = await axios.get<AckFailuresResponse>(
+        `${this.sdk.url}/neutron/contractmanager/failures/${addr}`,
+        { params: pagination },
+      );
+      return req.data;
+    } catch (e) {
+      if (e.response?.data?.message !== undefined) {
+        throw new Error(e.response?.data?.message);
+      }
+      throw e;
+    }
   }
 
   async msgDelegate(

--- a/src/testcases/simple.test.ts
+++ b/src/testcases/simple.test.ts
@@ -285,6 +285,7 @@ describe('Neutron / Simple', () => {
           async () => cm.queryAckFailures(contractAddress),
           // Wait until there 2 failure in the list
           (data) => data.failures.length == 4,
+          100,
         );
 
         console.log(failuresAfterCall.failures);

--- a/src/testcases/simple.test.ts
+++ b/src/testcases/simple.test.ts
@@ -328,9 +328,8 @@ describe('Neutron / Simple', () => {
           'pagination.limit': '1',
           'pagination.offset': '0',
         };
-        await expect(
-          cm.queryAckFailures(contractAddress, pagination),
-        ).resolves.toReturn();
+        const failures = await cm.queryAckFailures(contractAddress, pagination);
+        expect(failures.failures.length).toEqual(1);
       });
       test('failures with big limit returns an error', async () => {
         const pagination: PageRequest = {

--- a/src/testcases/simple.test.ts
+++ b/src/testcases/simple.test.ts
@@ -323,7 +323,16 @@ describe('Neutron / Simple', () => {
       });
     });
     describe('Failures limit test', () => {
-      test('failures with big limit returns error', async () => {
+      test("failures with small limit doesn't return an error", async () => {
+        const pagination: PageRequest = {
+          'pagination.limit': '1',
+          'pagination.offset': '0',
+        };
+        await expect(
+          cm.queryAckFailures(contractAddress, pagination),
+        ).resolves.toReturn();
+      });
+      test('failures with big limit returns an error', async () => {
         const pagination: PageRequest = {
           'pagination.limit': '10000',
           'pagination.offset': '0',

--- a/src/testcases/simple.test.ts
+++ b/src/testcases/simple.test.ts
@@ -4,6 +4,7 @@ import {
   COSMOS_DENOM,
   IBC_RELAYER_NEUTRON_ADDRESS,
   NEUTRON_DENOM,
+  PageRequest,
 } from '../helpers/cosmos';
 import { getRemoteHeight, getWithAttempts, waitBlocks } from '../helpers/wait';
 import { TestStateLocalCosmosTestNet } from './common_localcosmosnet';
@@ -317,6 +318,17 @@ describe('Neutron / Simple', () => {
             integration_tests_unset_sudo_failure_mock: {},
           }),
         );
+      });
+    });
+    describe('Failures limit test', () => {
+      test('failures with big limit returns error', async () => {
+        const pagination: PageRequest = {
+          'pagination.limit': '10000',
+          'pagination.offset': '0',
+        };
+        await expect(
+          cm.queryAckFailures(contractAddress, pagination),
+        ).rejects.toThrow(/limit is more than maximum allowed/);
       });
     });
   });


### PR DESCRIPTION
This PR adds simple test for the fix made in Neutron: https://github.com/neutron-org/neutron/pull/96

During the review please ensure test fails with Neutron from the main (`neutron_audit_oak_19_09_2022_fixes`) branch and passes with `fix/query-failures-limit` branch.