### PR TITLE
Feerefunder events test

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "express": "^4.17.1",
     "jest": "^27.5.1",
     "lodash": "^4.17.21",
-    "long": "^5.2.0"
+    "long": "^5.2.0",
+    "ws": "^8.11.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5647,6 +5647,11 @@ ws@^7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
   integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
 
+ws@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
+  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"


### PR DESCRIPTION
This PR appeared as an attempt to cover this PR in Neutron: https://github.com/neutron-org/neutron/pull/97
To do so, it adds to the integration tests framework the code to subscribe to an events.