### PR TITLE
fix: NTRN-278. Fix integration tests to work with interchain security

### DIFF
--- a/setup/dockerbuilds/Dockerfile.gaia
+++ b/setup/dockerbuilds/Dockerfile.gaia
@@ -19,4 +19,5 @@ EXPOSE 26656 26657 1317 9090
 USER 0
 
 CMD sh /opt/node/setup/init.sh && \
+  sh /opt/node/setup/add-gentx.sh && \
   sh /opt/node/setup/start.sh

--- a/setup/dockerbuilds/Dockerfile.hermes
+++ b/setup/dockerbuilds/Dockerfile.hermes
@@ -2,10 +2,12 @@ FROM rust:1.63-bullseye
 ADD ./hermes/ /app/network/hermes/
 WORKDIR /app
 RUN PLATFORM=`uname -a | awk '{print $(NF-1)}'` && \
-    curl -L "https://github.com/informalsystems/ibc-rs/releases/download/v1.0.0/hermes-v1.0.0-${PLATFORM}-unknown-linux-gnu.tar.gz" > hermes.tar.gz && \
+    git clone https://github.com/informalsystems/hermes.git && \
+    cd hermes && \
+    git checkout 7defaf067dbe6f60588518ea1619f228d38ac48d && \
+    cargo build --release --bin hermes && \
     mkdir -p $HOME/.hermes/bin && \
-    tar -C $HOME/.hermes/bin/ -vxzf hermes.tar.gz && \
-    rm -f hermes.tar.gz 
+    mv ./target/release/hermes $HOME/.hermes/bin/
 ENV PATH="/root/.hermes/bin:${PATH}"
 
 CMD /app/network/hermes/restore-keys.sh && \

--- a/setup/dockerbuilds/Dockerfile.neutron
+++ b/setup/dockerbuilds/Dockerfile.neutron
@@ -11,4 +11,5 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD \
     curl -f http://127.0.0.1:1317/blocks/1 >/dev/null 2>&1 || exit 1
 
 CMD sh /opt/neutron/setup/init.sh && \
+    sh /opt/neutron/setup/add-consumer-section.sh && \
     sh /opt/neutron/setup/start.sh

--- a/setup/hermes/config.toml
+++ b/setup/hermes/config.toml
@@ -107,6 +107,7 @@ max_tx_size = 2097152
 clock_drift = '5s'
 max_block_time = '10s'
 trusting_period = '14days'
+unbonding_period = '20days'
 trust_threshold = { numerator = '1', denominator = '3' }
 address_type = { derivation = 'cosmos' }
 
@@ -128,5 +129,6 @@ max_tx_size = 2097152
 clock_drift = '5s'
 max_block_time = '10s'
 trusting_period = '14days'
+unbonding_period = '21days'
 trust_threshold = { numerator = '1', denominator = '3' }
 address_type = { derivation = 'cosmos' }

--- a/setup/node/add-consumer-section.sh
+++ b/setup/node/add-consumer-section.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BINARY=${BINARY:-neutrond}
+CHAIN_DIR=./data
+CHAINID=${CHAINID:-test-1}
+
+echo "Add consumer section..."
+$BINARY add-consumer-section --home $CHAIN_DIR/$CHAINID

--- a/setup/node/add-gentx.sh
+++ b/setup/node/add-gentx.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+BINARY=${BINARY:-neutrond}
+CHAIN_DIR=./data
+CHAINID=${CHAINID:-test-1}
+
+STAKEDENOM=${STAKEDENOM:-stake}
+
+echo "Creating and collecting gentx..."
+$BINARY gentx val1 7000000000${STAKEDENOM} --home $CHAIN_DIR/$CHAINID --chain-id $CHAINID --keyring-backend test
+$BINARY collect-gentxs --home $CHAIN_DIR/$CHAINID

--- a/setup/node/init.sh
+++ b/setup/node/init.sh
@@ -50,10 +50,6 @@ $BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show demow
 $BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show rly1 --keyring-backend test -a) 100000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
 $BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show rly2 --keyring-backend test -a) 100000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
 
-echo "Creating and collecting gentx..."
-$BINARY gentx val1 7000000000${STAKEDENOM} --home $CHAIN_DIR/$CHAINID --chain-id $CHAINID --keyring-backend test
-$BINARY collect-gentxs --home $CHAIN_DIR/$CHAINID
-
 sed -i -e 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' $CHAIN_DIR/$CHAINID/config/config.toml
 sed -i -e 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAIN_DIR/$CHAINID/config/config.toml
 sed -i -e 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAIN_DIR/$CHAINID/config/config.toml


### PR DESCRIPTION
Make integration tests work with latest version of neutron with CCV modules.
It should work with `main` version of `neutron`.