### PR TITLE
fix: NTRN-267. Interchaintx tests. Add counterparty chain connection to be established

### DIFF
--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -61,7 +61,12 @@ export const waitForChannel = async (
       const r = await axios.get(`${host}/ibc/core/channel/v1/channels`, {
         timeout: 1000,
       });
-      if (r.data.channels.length > 0) {
+      if (
+        r.data.channels.length > 0 &&
+        r.data.channels.every(
+          (channel: any) => channel.counterparty.channel_id !== '',
+        )
+      ) {
         return;
       }
       // eslint-disable-next-line no-empty

--- a/src/helpers/wait.ts
+++ b/src/helpers/wait.ts
@@ -1,8 +1,8 @@
 import { rest } from '@cosmos-client/core';
 
-export const wait = async (n: number) =>
+export const wait = async (seconds: number) =>
   new Promise((r) => {
-    setTimeout(() => r(true), n);
+    setTimeout(() => r(true), 1000 * seconds);
   });
 
 /*
@@ -19,7 +19,7 @@ export const getRemoteHeight = async (sdk: any) => {
 export const waitBlocks = async (sdk: any, n: number) => {
   const targetHeight = (await getRemoteHeight(sdk)) + n;
   for (;;) {
-    await wait(10);
+    await wait(1);
     const currentHeight = await getRemoteHeight(sdk);
     if (currentHeight >= targetHeight) {
       break;

--- a/src/testcases/interchaintx.test.ts
+++ b/src/testcases/interchaintx.test.ts
@@ -53,6 +53,7 @@ describe('Neutron / Interchain TXs', () => {
           JSON.stringify({}),
           'interchaintx',
         );
+
         contractAddress = res;
         expect(res.toString()).toEqual(
           'neutron14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s5c2epq',
@@ -104,6 +105,7 @@ describe('Neutron / Interchain TXs', () => {
           },
         ]);
       });
+
       test('get ica address', async () => {
         const ica1 = await getIca(cm1, contractAddress, icaId1, connectionId);
         expect(ica1.interchain_account_address).toStartWith('cosmos');
@@ -115,6 +117,7 @@ describe('Neutron / Interchain TXs', () => {
         expect(ica2.interchain_account_address.length).toEqual(65);
         icaAddress2 = ica2.interchain_account_address;
       });
+
       test('set payer fees', async () => {
         const res = await cm1.executeContract(
           contractAddress,

--- a/src/testcases/interchaintx.test.ts
+++ b/src/testcases/interchaintx.test.ts
@@ -522,7 +522,7 @@ describe('Neutron / Interchain TXs', () => {
         async () => cm1.queryAckFailures(contractAddress),
         // Wait until there 2 failure in the list
         (data) => data.failures.length == 2,
-        20,
+        100,
       );
 
       expect(failuresAfterCall.failures).toEqual([


### PR DESCRIPTION
Because of delay in the connection creation using query relayer it is required to change approach used to detect connection established event.