### PR TITLE
chore: NTRN-288: use websocket to wait for new block

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ CONTRACTS_PATH - path to contracts that will be used in tests
 NEUTRON_ADDRESS_PREFIX - address prefix for neutron controller network
 COSMOS_ADDRESS_PREFIX - address prefix for gaia (cosmoshub) host network
 NODE1_URL - url to the first node
+NODE1_WS_URL - url to websocket of the first node
 NODE2_URL - url to the second node
+NODE2_WS_URL - url to websocket of the second node
 BLOCKS_COUNT_BEFORE_START - how many blocks we wait before start first test
 NO_DOCKER - do not start cosmopark for tests
 NO_REBUILD - skip containers rebuilding

--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -257,7 +257,7 @@ export class CosmosWrapper {
     const txhash = res.data?.tx_response.txhash;
     let error = null;
     while (numAttempts > 0) {
-      await this.blockWaiter.next();
+      await this.blockWaiter.waitBlocks(1);
       numAttempts--;
       const data = await rest.tx
         .getTx(this.sdk as CosmosSDK, txhash)
@@ -372,7 +372,7 @@ export class CosmosWrapper {
       }
 
       numAttempts--;
-      await this.blockWaiter.next();
+      await this.blockWaiter.waitBlocks(1);
     }
 
     throw new Error('failed to query contract');

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -9,7 +9,7 @@ const BLOCKS_COUNT_BEFORE_START = process.env.BLOCKS_COUNT_BEFORE_START
 
 let alreadySetUp = false;
 
-export const setup = async (host: string) => {
+export const setup = async (host1: string, host2: string) => {
   if (alreadySetUp) {
     console.log('already set up');
     return;
@@ -32,8 +32,12 @@ export const setup = async (host: string) => {
   showVersions();
   await showContractsHashes();
 
-  await waitForHTTP(host);
-  await waitForChannel(host);
+  await waitForHTTP(host1);
+  await waitForChannel(host1);
+  await waitForHTTP(host2);
+  await waitForChannel(host2);
+  await wait(20); // FIXME: this hardcoded sleep is here to wait until hermes is fully initialized.
+  //                        proper fix would be to monitor hermes status events.
   alreadySetUp = true;
 };
 
@@ -53,7 +57,7 @@ export const waitForHTTP = async (
       }
       // eslint-disable-next-line no-empty
     } catch (e) {}
-    await wait(10);
+    await wait(1);
   }
   throw new Error('No port opened');
 };
@@ -80,7 +84,7 @@ export const waitForChannel = async (
       }
       // eslint-disable-next-line no-empty
     } catch (e) {}
-    await wait(10);
+    await wait(1);
   }
 
   throw new Error('No channel opened');

--- a/src/helpers/ica.ts
+++ b/src/helpers/ica.ts
@@ -9,7 +9,7 @@ export const getIca = (
   numAttempts = 20,
 ) =>
   getWithAttempts(
-    cm.sdk,
+    cm,
     () =>
       cm.queryContract<{
         interchain_account_address: string;

--- a/src/helpers/icq.ts
+++ b/src/helpers/icq.ts
@@ -48,7 +48,7 @@ export const waitForICQResultWithRemoteHeight = (
   numAttempts = 20,
 ) =>
   getWithAttempts(
-    cm.sdk,
+    cm,
     () => getRegisteredQuery(cm, contractAddress, queryId),
     async (query) =>
       query.registered_query.last_submitted_result_remote_height >=
@@ -80,7 +80,7 @@ export const waitForTransfersAmount = (
   numAttempts = 50,
 ) =>
   getWithAttempts(
-    cm.sdk,
+    cm,
     async () =>
       (await queryTransfersNumber(cm, contractAddress)).transfers_number,
     async (amount) => amount == expectedTransfersAmount,

--- a/src/helpers/wait.ts
+++ b/src/helpers/wait.ts
@@ -1,4 +1,6 @@
-import { rest } from '@cosmos-client/core';
+import { rest, websocket } from '@cosmos-client/core';
+
+(global as any).WebSocket = require('ws');
 
 export const wait = async (seconds: number) =>
   new Promise((r) => {
@@ -16,23 +18,45 @@ export const getRemoteHeight = async (sdk: any) => {
   return +block.data.block.header.height;
 };
 
-export const waitBlocks = async (sdk: any, n: number) => {
-  const targetHeight = (await getRemoteHeight(sdk)) + n;
-  for (;;) {
-    await wait(1);
-    const currentHeight = await getRemoteHeight(sdk);
-    if (currentHeight >= targetHeight) {
-      break;
+export class BlockWaiter {
+  url;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  next() {
+    return new Promise((r) => {
+      const ws = websocket.connect(this.url);
+      ws.next({
+        id: '1',
+        jsonrpc: '2.0',
+        method: 'subscribe',
+        params: ["tm.event='NewBlock'"],
+      });
+      ws.subscribe((x) => {
+        if (Object.entries((x as any).result).length !== 0) {
+          ws.unsubscribe();
+          r(x);
+        }
+      });
+    });
+  }
+
+  async waitBlocks(n: number) {
+    while (n > 0) {
+      await this.next();
+      n--;
     }
   }
-};
+}
 
 /**
  * getWithAttempts waits until readyFunc(getFunc()) returns true
  * and only then returns result of getFunc()
  */
 export const getWithAttempts = async <T>(
-  sdk: any,
+  cm: any,
   getFunc: () => Promise<T>,
   readyFunc: (t: T) => Promise<boolean>,
   numAttempts = 20,
@@ -48,7 +72,7 @@ export const getWithAttempts = async <T>(
     } catch (e) {
       error = e;
     }
-    await waitBlocks(sdk, 1);
+    await cm.blockWaiter.next();
   }
   throw error != null ? error : new Error('getWithAttempts: no attempts left');
 };

--- a/src/testcases/common_localcosmosnet.ts
+++ b/src/testcases/common_localcosmosnet.ts
@@ -3,6 +3,7 @@ import { cosmosclient } from '@cosmos-client/core';
 import { Wallet } from '../types';
 import { mnemonicToWallet } from '../helpers/cosmos';
 import { setup } from '../helpers/env';
+import { BlockWaiter } from '../helpers/wait';
 
 const config = require('../config.json');
 
@@ -56,6 +57,8 @@ const walletSet = async (
 export class TestStateLocalCosmosTestNet {
   sdk1: cosmosclient.CosmosSDK;
   sdk2: cosmosclient.CosmosSDK;
+  blockWaiter1: BlockWaiter;
+  blockWaiter2: BlockWaiter;
   wallets: Record<string, Record<string, Wallet>>;
   icq_web_host: string;
   init = async () => {
@@ -70,7 +73,14 @@ export class TestStateLocalCosmosTestNet {
 
     this.icq_web_host = 'http://localhost:9999';
 
-    await setup(host1);
+    this.blockWaiter1 = new BlockWaiter(
+      process.env.NODE1_WS_URL || 'ws://localhost:26657',
+    );
+    this.blockWaiter2 = new BlockWaiter(
+      process.env.NODE2_WS_URL || 'ws://localhost:16657',
+    );
+
+    await setup(host1, host2);
 
     this.wallets = {};
     this.wallets.neutron = await walletSet(this.sdk1, neutron_prefix);

--- a/src/testcases/governance.test.ts
+++ b/src/testcases/governance.test.ts
@@ -21,16 +21,19 @@ describe('Neutron / Governance', () => {
     await testState.init();
     cm = new CosmosWrapper(
       testState.sdk1,
+      testState.blockWaiter1,
       testState.wallets.neutron.demo1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk1,
+      testState.blockWaiter1,
       testState.wallets.neutron.demo2,
       NEUTRON_DENOM,
     );
     cm3 = new CosmosWrapper(
       testState.sdk1,
+      testState.blockWaiter1,
       testState.wallets.neutron.rly1,
       NEUTRON_DENOM,
     );
@@ -44,7 +47,7 @@ describe('Neutron / Governance', () => {
         cm.wallet.address.toString(),
       );
       await getWithAttempts(
-        cm.sdk,
+        cm,
         async () =>
           await cm.queryVotingPower(
             CORE_CONTRACT_ADDRESS,
@@ -61,7 +64,7 @@ describe('Neutron / Governance', () => {
         cm2.wallet.address.toString(),
       );
       await getWithAttempts(
-        cm2.sdk,
+        cm2,
         async () =>
           await cm2.queryVotingPower(
             CORE_CONTRACT_ADDRESS,
@@ -78,7 +81,7 @@ describe('Neutron / Governance', () => {
         cm3.wallet.address.toString(),
       );
       await getWithAttempts(
-        cm3.sdk,
+        cm3,
         async () =>
           await cm3.queryVotingPower(
             CORE_CONTRACT_ADDRESS,
@@ -90,7 +93,7 @@ describe('Neutron / Governance', () => {
     });
     test('check voting power', async () => {
       await getWithAttempts(
-        cm.sdk,
+        cm,
         async () => await cm.queryTotalVotingPower(CORE_CONTRACT_ADDRESS),
         async (response) => response.power == '3000',
         20,
@@ -102,7 +105,7 @@ describe('Neutron / Governance', () => {
     test('send funds from wallet 1', async () => {
       await cm.msgSend(CORE_CONTRACT_ADDRESS, '1000');
       await getWithAttempts(
-        cm.sdk,
+        cm,
         async () => await cm.queryBalances(CORE_CONTRACT_ADDRESS),
         async (response) => response.balances[0].amount == '1000',
         20,
@@ -291,7 +294,7 @@ describe('Neutron / Governance', () => {
       }
       expect(rawLog.includes("proposal is not in 'passed' state"));
       await getWithAttempts(
-        cm.sdk,
+        cm,
         async () =>
           await cm.queryProposal(PROPOSE_CONTRACT_ADDRESS, proposalId),
         async (response) => response.proposal.status === 'rejected',

--- a/src/testcases/interchain_kv_query.test.ts
+++ b/src/testcases/interchain_kv_query.test.ts
@@ -3,10 +3,10 @@ import {
   COSMOS_DENOM,
   CosmosWrapper,
   NEUTRON_DENOM,
-  VAULT_CONTRACT_ADDRESS,
-  PRE_PROPOSE_CONTRACT_ADDRESS,
   NeutronContract,
+  PRE_PROPOSE_CONTRACT_ADDRESS,
   PROPOSE_CONTRACT_ADDRESS,
+  VAULT_CONTRACT_ADDRESS,
 } from '../helpers/cosmos';
 import { TestStateLocalCosmosTestNet } from './common_localcosmosnet';
 import { getRemoteHeight, getWithAttempts } from '../helpers/wait';
@@ -181,14 +181,14 @@ const acceptInterchainqueriesParamsChangeProposal = async (
   const proposalId = parseInt(attribute);
   expect(proposalId).toBeGreaterThanOrEqual(0);
 
-  await cm.blockWaiter.next();
+  await cm.blockWaiter.waitBlocks(1);
   await cm.voteYes(
     PROPOSE_CONTRACT_ADDRESS,
     proposalId,
     wallet.address.toString(),
   );
 
-  await cm.blockWaiter.next();
+  await cm.blockWaiter.waitBlocks(1);
   await cm.executeProposal(
     PROPOSE_CONTRACT_ADDRESS,
     proposalId,
@@ -612,7 +612,7 @@ describe('Neutron / Interchain KV Query', () => {
         for (const j of res) {
           expect(j).not.toEqual(0);
         }
-        await cm[1].blockWaiter.next();
+        await cm[1].blockWaiter.waitBlocks(1);
       }
       const end = await Promise.all(
         [2, 3, 4].map((i) => getKvCallbackStatus(cm[1], contractAddress, i)),
@@ -673,7 +673,7 @@ describe('Neutron / Interchain KV Query', () => {
           testState.wallets.cosmos.demo2.address,
         );
 
-        await cm[1].blockWaiter.next();
+        await cm[1].blockWaiter.waitBlocks(1);
 
         const queryResult = await getRegisteredQuery(
           cm[1],
@@ -733,7 +733,7 @@ describe('Neutron / Interchain KV Query', () => {
           testState.wallets.cosmos.demo2.address,
         );
 
-        await cm[1].blockWaiter.next();
+        await cm[1].blockWaiter.waitBlocks(1);
 
         const queryResult = await getRegisteredQuery(
           cm[1],

--- a/src/testcases/interchain_tx_query_resubmit.test.ts
+++ b/src/testcases/interchain_tx_query_resubmit.test.ts
@@ -1,6 +1,5 @@
 import { COSMOS_DENOM, CosmosWrapper, NEUTRON_DENOM } from '../helpers/cosmos';
 import { TestStateLocalCosmosTestNet } from './common_localcosmosnet';
-import { waitBlocks } from '../helpers/wait';
 import {
   getRegisteredQuery,
   getUnsuccessfulTxs,
@@ -22,11 +21,13 @@ describe('Neutron / Interchain TX Query Resubmit', () => {
     await testState.init();
     cm = new CosmosWrapper(
       testState.sdk1,
+      testState.blockWaiter1,
       testState.wallets.neutron.demo1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk2,
+      testState.blockWaiter2,
       testState.wallets.cosmos.demo2,
       COSMOS_DENOM,
     );
@@ -96,7 +97,7 @@ describe('Neutron / Interchain TX Query Resubmit', () => {
         expect(res.code).toEqual(0);
       }
 
-      await waitBlocks(cm.sdk, 5);
+      await cm.blockWaiter.waitBlocks(5);
 
       const txs = await getUnsuccessfulTxs(testState.icq_web_host);
       expect(txs.length).toEqual(5);
@@ -116,7 +117,7 @@ describe('Neutron / Interchain TX Query Resubmit', () => {
       const resp = await postResubmitTxs(testState.icq_web_host, resubmit_txs);
       expect(resp.status).toEqual(200);
 
-      await waitBlocks(cm.sdk, 20);
+      await cm.blockWaiter.waitBlocks(20);
 
       await waitForTransfersAmount(
         cm,

--- a/src/testcases/interchaintx.test.ts
+++ b/src/testcases/interchaintx.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../helpers/cosmos';
 import { AcknowledgementResult } from '../helpers/contract_types';
 import { TestStateLocalCosmosTestNet } from './common_localcosmosnet';
-import { getWithAttempts, waitBlocks } from '../helpers/wait';
+import { getWithAttempts } from '../helpers/wait';
 import { CosmosSDK } from '@cosmos-client/core/cjs/sdk';
 import { getIca } from '../helpers/ica';
 
@@ -31,11 +31,13 @@ describe('Neutron / Interchain TXs', () => {
     await testState.init();
     cm1 = new CosmosWrapper(
       testState.sdk1,
+      testState.blockWaiter1,
       testState.wallets.neutron.demo1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk2,
+      testState.blockWaiter2,
       testState.wallets.cosmos.demo2,
       COSMOS_DENOM,
     );
@@ -83,7 +85,7 @@ describe('Neutron / Interchain TXs', () => {
       });
       test('multiple IBC accounts created', async () => {
         const channels = await getWithAttempts(
-          cm1.sdk,
+          cm1,
           () => cm1.listIBCChannels(),
           // Wait until there are 3 channels:
           // - one exists already, it is open for IBC transfers;
@@ -177,7 +179,7 @@ describe('Neutron / Interchain TXs', () => {
       });
       test('check validator state', async () => {
         const res1 = await getWithAttempts(
-          cm2.sdk,
+          cm2,
           () =>
             rest.staking.delegatorDelegations(
               cm2.sdk as CosmosSDK,
@@ -427,7 +429,7 @@ describe('Neutron / Interchain TXs', () => {
         );
         expect(res.code).toEqual(0);
         await getWithAttempts(
-          cm1.sdk,
+          cm1,
           async () => cm1.listIBCChannels(),
           // Wait until there are 4 channels:
           // - one exists already, it is open for IBC transfers;
@@ -436,7 +438,7 @@ describe('Neutron / Interchain TXs', () => {
           async (channels) => channels.channels.length == 4,
         );
         await getWithAttempts(
-          cm1.sdk,
+          cm1,
           () => cm1.listIBCChannels(),
           async (channels) =>
             channels.channels.find((c) => c.channel_id == 'channel-3').state ==
@@ -510,7 +512,7 @@ describe('Neutron / Interchain TXs', () => {
         }),
       );
 
-      await waitBlocks(cm1.sdk, 10);
+      await cm1.blockWaiter.waitBlocks(10);
 
       // Testing ACK timeout failure
       await cm1.executeContract(
@@ -527,7 +529,7 @@ describe('Neutron / Interchain TXs', () => {
       );
 
       const failuresAfterCall = await getWithAttempts<AckFailuresResponse>(
-        cm1.sdk,
+        cm1,
         async () => cm1.queryAckFailures(contractAddress),
         // Wait until there 2 failure in the list
         async (data) => data.failures.length == 2,
@@ -579,7 +581,7 @@ const waitForAck = (
   numAttempts = 20,
 ) =>
   getWithAttempts(
-    cm.sdk,
+    cm,
     () =>
       cm.queryContract<AcknowledgementResult>(contractAddress, {
         acknowledgement_result: {

--- a/src/testcases/subdao.test.ts
+++ b/src/testcases/subdao.test.ts
@@ -60,7 +60,7 @@ describe('Neutron / Subdao', () => {
 
     await cm.bondFunds(VAULT_CONTRACT_ADDRESS, '10000');
     await getWithAttempts(
-      cm.sdk,
+      cm,
       async () =>
         await cm.queryVotingPower(
           subDAO.core.address,

--- a/src/testcases/subdao.test.ts
+++ b/src/testcases/subdao.test.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   CosmosWrapper,
-  NEUTRON_DENOM,
-  VAULT_CONTRACT_ADDRESS,
-  getEventAttributesFromTx,
   createBankMassage,
+  getEventAttributesFromTx,
+  NEUTRON_DENOM,
   NeutronContract,
+  VAULT_CONTRACT_ADDRESS,
 } from '../helpers/cosmos';
 import { InlineResponse20075TxResponse } from '@cosmos-client/core/cjs/openapi/api';
 import {
@@ -14,12 +14,7 @@ import {
   TimeLockSingleChoiceProposal,
   SubDaoConfig,
 } from '../helpers/dao';
-import {
-  wait,
-  waitBlocks,
-  getWithAttempts,
-  getRemoteHeight,
-} from '../helpers/wait';
+import { getRemoteHeight, getWithAttempts, wait } from '../helpers/wait';
 import { TestStateLocalCosmosTestNet } from './common_localcosmosnet';
 import { AccAddress, ValAddress } from '@cosmos-client/core/cjs/types';
 import { Wallet } from '../types';
@@ -45,8 +40,18 @@ describe('Neutron / Subdao', () => {
     main_dao_addr = main_dao_wallet.address;
     security_dao_addr = security_dao_wallet.address;
     demo2_addr = demo2_wallet.address;
-    cm = new CosmosWrapper(testState.sdk1, main_dao_wallet, NEUTRON_DENOM);
-    cm3 = new CosmosWrapper(testState.sdk1, demo2_wallet, NEUTRON_DENOM);
+    cm = new CosmosWrapper(
+      testState.sdk1,
+      testState.blockWaiter1,
+      main_dao_wallet,
+      NEUTRON_DENOM,
+    );
+    cm3 = new CosmosWrapper(
+      testState.sdk1,
+      testState.blockWaiter1,
+      demo2_wallet,
+      NEUTRON_DENOM,
+    );
     subDAO = await setupSubDaoTimelockSet(
       cm,
       main_dao_addr.toString(),
@@ -393,7 +398,7 @@ describe('Neutron / Subdao', () => {
       expect(pauseInfo.paused.until_height).toBeGreaterThan(pauseHeight);
 
       // wait and check contract's pause info after unpausing
-      await waitBlocks(cm.sdk, short_pause_duration);
+      await cm.blockWaiter.waitBlocks(short_pause_duration);
       pauseInfo = await cm.queryPausedInfo(subDAO.core.address);
       expect(pauseInfo).toEqual({ unpaused: {} });
       expect(pauseInfo.paused).toEqual(undefined);

--- a/src/testcases/tokenomics.test.ts
+++ b/src/testcases/tokenomics.test.ts
@@ -20,11 +20,13 @@ describe('Neutron / Tokenomics', () => {
     await testState.init();
     cmNeutron = new CosmosWrapper(
       testState.sdk1,
+      testState.blockWaiter1,
       testState.wallets.neutron.demo1,
       NEUTRON_DENOM,
     );
     cmGaia = new CosmosWrapper(
       testState.sdk2,
+      testState.blockWaiter2,
       testState.wallets.cosmos.demo2,
       COSMOS_DENOM,
     );
@@ -147,7 +149,7 @@ describe('Neutron / Tokenomics', () => {
         { revision_number: 2, revision_height: 100000000 },
       );
       await getWithAttempts(
-        cmNeutron.sdk,
+        cmNeutron,
         async () =>
           cmNeutron.queryBalances(
             testState.wallets.neutron.demo1.address.toString(),

--- a/src/testcases/treasury.test.ts
+++ b/src/testcases/treasury.test.ts
@@ -32,11 +32,13 @@ describe('Neutron / Treasury', () => {
     await testState.init();
     cm = new CosmosWrapper(
       testState.sdk1,
+      testState.blockWaiter1,
       testState.wallets.neutron.demo1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk1,
+      testState.blockWaiter1,
       testState.wallets.neutron.demo2,
       NEUTRON_DENOM,
     );


### PR DESCRIPTION
Previous behaviour used to be HTTP polling busy loop.

[[NTRN-288](https://p2pvalidator.atlassian.net/browse/NTRN-288)] [[Test run](https://github.com/neutron-org/neutron-tests/actions/runs/3939510159)]

[NTRN-288]: https://p2pvalidator.atlassian.net/browse/NTRN-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ