### PR TITLE
feat: Implement burn-based vesting for treasury. NTRN-308

### DIFF
--- a/setup/node/init.sh
+++ b/setup/node/init.sh
@@ -42,13 +42,13 @@ echo $DEMO_MNEMONIC_3 | $BINARY keys add demowallet3 --home $CHAIN_DIR/$CHAINID 
 echo $RLY_MNEMONIC_1 | $BINARY keys add rly1 --home $CHAIN_DIR/$CHAINID --recover --keyring-backend=test
 echo $RLY_MNEMONIC_2 | $BINARY keys add rly2 --home $CHAIN_DIR/$CHAINID --recover --keyring-backend=test
 
-$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show val1 --keyring-backend test -a) 100000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
-$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show val2 --keyring-backend test -a) 100000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
-$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show demowallet1 --keyring-backend test -a) 100000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
-$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show demowallet2 --keyring-backend test -a) 100000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
-$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show demowallet3 --keyring-backend test -a) 100000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
-$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show rly1 --keyring-backend test -a) 100000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
-$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show rly2 --keyring-backend test -a) 100000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
+$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show val1 --keyring-backend test -a) 100000000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
+$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show val2 --keyring-backend test -a) 100000000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
+$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show demowallet1 --keyring-backend test -a) 100000000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
+$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show demowallet2 --keyring-backend test -a) 100000000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
+$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show demowallet3 --keyring-backend test -a) 100000000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
+$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show rly1 --keyring-backend test -a) 100000000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
+$BINARY add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAINID keys show rly2 --keyring-backend test -a) 100000000000000${STAKEDENOM}  --home $CHAIN_DIR/$CHAINID
 
 
 sed -i -e 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' $CHAIN_DIR/$CHAINID/config/config.toml

--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -855,6 +855,20 @@ export class CosmosWrapper {
     return req.data;
   }
 
+  async queryTotalBurnedNeutronsAmount(): Promise<TotalBurnedNeutronsAmountResponse> {
+    try {
+      const req = await axios.get<TotalBurnedNeutronsAmountResponse>(
+        `${this.sdk.url}/neutron/feeburner/total_burned_neutrons_amount`,
+      );
+      return req.data;
+    } catch (e) {
+      if (e.response?.data?.message !== undefined) {
+        throw new Error(e.response?.data?.message);
+      }
+      throw e;
+    }
+  }
+
   async queryTotalSupplyByDenom(
     denom: string,
   ): Promise<TotalSupplyByDenomResponse> {

--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -876,20 +876,6 @@ export class CosmosWrapper {
     return req.data;
   }
 
-  async queryTotalBurnedNeutronsAmount(): Promise<TotalBurnedNeutronsAmountResponse> {
-    try {
-      const req = await axios.get<TotalBurnedNeutronsAmountResponse>(
-        `${this.sdk.url}/neutron/feeburner/total_burned_neutrons_amount`,
-      );
-      return req.data;
-    } catch (e) {
-      if (e.response?.data?.message !== undefined) {
-        throw new Error(e.response?.data?.message);
-      }
-      throw e;
-    }
-  }
-
   async queryTotalSupplyByDenom(
     denom: string,
   ): Promise<TotalSupplyByDenomResponse> {

--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -55,7 +55,7 @@ export type TotalSupplyByDenomResponse = {
   amount: ICoin;
 };
 
-// TotalBurnedNeutronsAmountResponse is the response model for the feeburner's  total-burned-neutrons.
+// TotalBurnedNeutronsAmountResponse is the response model for the feeburner's total-burned-neutrons.
 export type TotalBurnedNeutronsAmountResponse = {
   total_burned_neutrons_amount: {
     coin: ICoin;
@@ -123,13 +123,6 @@ export type AckFailuresResponse = {
   pagination: {
     next_key: string;
     total: string;
-  };
-};
-
-// TotalBurnedNeutronsAmount is the response model for the feeburner's  total-burned-neutrons.
-export type TotalBurnedNeutronsAmount = {
-  total_burned_neutrons_amount: {
-    coins: ICoin[];
   };
 };
 
@@ -810,20 +803,6 @@ export class CosmosWrapper {
       const req = await axios.get<AckFailuresResponse>(
         `${this.sdk.url}/neutron/contractmanager/failures/${addr}`,
         { params: pagination },
-      );
-      return req.data;
-    } catch (e) {
-      if (e.response?.data?.message !== undefined) {
-        throw new Error(e.response?.data?.message);
-      }
-      throw e;
-    }
-  }
-
-  async queryTotalBurnedNeutronsAmount(): Promise<TotalBurnedNeutronsAmount> {
-    try {
-      const req = await axios.get<TotalBurnedNeutronsAmount>(
-        `${this.sdk.url}/neutron/feeburner/total_burned_neutrons_amount`,
       );
       return req.data;
     } catch (e) {

--- a/src/testcases/treasury.test.ts
+++ b/src/testcases/treasury.test.ts
@@ -77,6 +77,7 @@ describe('Neutron / Treasury', () => {
           minPeriod: 1000,
           distributionContract: dsc,
           reserveContract: reserve,
+          vestingDenominator: '100000000000',
         });
         await expect(
           cm.executeContract(
@@ -160,15 +161,14 @@ describe('Neutron / Treasury', () => {
         expect(treasuryBalance).toEqual(0);
 
         // Third distribution
-        await cm.executeContract(
-          treasury,
-          JSON.stringify({
-            distribute: {},
-          }),
-        );
-
-        treasuryBalance = await cm.queryDenomBalance(treasury, cm.denom);
-        expect(treasuryBalance).toEqual(0);
+        await expect(
+          cm.executeContract(
+            treasury,
+            JSON.stringify({
+              distribute: {},
+            }),
+          ),
+        ).rejects.toThrow(/No funds to distribute/);
       });
       test('set shares by unauthorized', async () => {
         await expect(
@@ -247,6 +247,7 @@ describe('Neutron / Treasury', () => {
           minPeriod: 1,
           distributionContract: dsc,
           reserveContract: reserve,
+          vestingDenominator: '100000000000',
         });
         await cm.executeContract(
           dsc,
@@ -392,6 +393,7 @@ describe('Neutron / Treasury', () => {
           minPeriod: 1000,
           distributionContract: dsc,
           reserveContract: reserve,
+          vestingDenominator: '100000000000',
         });
       });
       test('update treasury config by unauthorized', async () => {

--- a/src/testcases/treasury.test.ts
+++ b/src/testcases/treasury.test.ts
@@ -112,7 +112,7 @@ describe('Neutron / Treasury', () => {
       });
       test('burned coins increment', async () => {
         await cm.msgSend(treasury, '100000');
-        let burnedCoins = await getBurnedCoinsAmount(cm, cm.denom);
+        let burnedCoins = await getBurnedCoinsAmount(cm);
         await cm.executeContract(
           treasury,
           JSON.stringify({
@@ -123,7 +123,7 @@ describe('Neutron / Treasury', () => {
         let stats = (await cm.queryContract(treasury, { stats: {} })) as any;
         expect(stats.total_processed_burned_coins).toEqual(burnedCoins);
 
-        burnedCoins = await getBurnedCoinsAmount(cm, cm.denom);
+        burnedCoins = await getBurnedCoinsAmount(cm);
         await cm.executeContract(
           treasury,
           JSON.stringify({
@@ -219,7 +219,7 @@ describe('Neutron / Treasury', () => {
             parseInt(treasuryStats.total_processed_burned_coins),
         ).toEqual(4_294_967_295);
 
-        const burnedCoins = await getBurnedCoinsAmount(cm, cm.denom);
+        const burnedCoins = await getBurnedCoinsAmount(cm);
 
         await cm.executeContract(
           treasury,
@@ -263,7 +263,7 @@ describe('Neutron / Treasury', () => {
 
       test('fund', async () => {
         treasuryStats = await normalizeTreasuryBurnedCoins(cm, treasury);
-        const burnedCoinsBefore = await getBurnedCoinsAmount(cm, cm.denom);
+        const burnedCoinsBefore = await getBurnedCoinsAmount(cm);
         await cm.simulateFeeBurning(20_000_000);
         await cm.msgSend(treasury, '1000000000');
 
@@ -275,7 +275,7 @@ describe('Neutron / Treasury', () => {
         );
         expect(res.code).toEqual(0);
 
-        const burnedCoinsAfter = await getBurnedCoinsAmount(cm, cm.denom);
+        const burnedCoinsAfter = await getBurnedCoinsAmount(cm);
 
         const stats = await cm.queryContract(treasury, { stats: {} });
         expect(stats).toEqual(
@@ -587,7 +587,7 @@ const normalizeTreasuryBurnedCoins = async (
       stats: {},
     });
 
-    const burnedCoins = await getBurnedCoinsAmount(cm, cm.denom);
+    const burnedCoins = await getBurnedCoinsAmount(cm);
     normalize =
       parseInt(treasuryStats.total_processed_burned_coins) + 7500 !==
       parseInt(burnedCoins!);
@@ -601,9 +601,7 @@ const getBurnedCoinsAmount = async (
   denom: string,
 ): Promise<string | undefined | null> => {
   const totalBurnedNeutrons = await cm.queryTotalBurnedNeutronsAmount();
-  return totalBurnedNeutrons.total_burned_neutrons_amount.coins.find(
-    (coin) => coin.denom === denom,
-  )?.amount;
+  return totalBurnedNeutrons.total_burned_neutrons_amount.coin.amount;
 };
 
 const setupReserve = async (

--- a/src/testcases/treasury.test.ts
+++ b/src/testcases/treasury.test.ts
@@ -74,30 +74,15 @@ describe('Neutron / Treasury', () => {
           mainDaoAddress: main_dao_addr.toString(),
           securityDaoAddress: security_dao_addr.toString(),
           distributionRate: '0.0',
-          minPeriod: 1000,
+          minPeriod: 1,
           distributionContract: dsc,
           reserveContract: reserve,
           vestingDenominator: '100000000000',
         });
-        await expect(
-          cm.executeContract(
-            treasury,
-            JSON.stringify({
-              distribute: {},
-            }),
-          ),
-        ).rejects.toThrow(/No funds to distribute/);
+
+        treasuryStats = await normalizeTreasuryBurnedCoins(cm, treasury);
       });
       test('zero distribution rate', async () => {
-        treasury = await setupTreasury(cm, {
-          mainDaoAddress: main_dao_addr.toString(),
-          securityDaoAddress: security_dao_addr.toString(),
-          distributionRate: '0.0',
-          minPeriod: 1000,
-          distributionContract: dsc,
-          reserveContract: reserve,
-          vestingDenominator: '100000000000',
-        });
         await cm.msgSend(treasury, '100000');
         const res = await cm.executeContract(
           treasury,
@@ -507,9 +492,9 @@ describe('Neutron / Treasury', () => {
         async () => {
           const stats = await cm.queryContract(treasury, { stats: {} });
           expect(stats).toEqual({
-            total_received: '10000000',
-            total_distributed: '2100000',
-            total_reserved: '7900000',
+            total_distributed: '88284',
+            total_reserved: '332120',
+            total_processed_burned_coins: '4294967295',
           });
         },
       );
@@ -528,7 +513,7 @@ describe('Neutron / Treasury', () => {
             JSON.stringify({
               payout: {
                 recipient: holder_2_addr.toString(),
-                amount: '1400000',
+                amount: '332120',
               },
             }),
           );
@@ -539,7 +524,7 @@ describe('Neutron / Treasury', () => {
             holder_2_addr,
             NEUTRON_DENOM,
           );
-          expect(balanceAfter - balanceBefore).toEqual(1400000);
+          expect(balanceAfter - balanceBefore).toEqual(332120);
         },
       );
     });

--- a/src/testcases/treasury.test.ts
+++ b/src/testcases/treasury.test.ts
@@ -73,7 +73,7 @@ describe('Neutron / Treasury', () => {
         treasury = await setupTreasury(cm, {
           mainDaoAddress: main_dao_addr.toString(),
           securityDaoAddress: security_dao_addr.toString(),
-          distributionRate: '0.23',
+          distributionRate: '0.0',
           minPeriod: 1000,
           distributionContract: dsc,
           reserveContract: reserve,
@@ -96,6 +96,7 @@ describe('Neutron / Treasury', () => {
           minPeriod: 1000,
           distributionContract: dsc,
           reserveContract: reserve,
+          vestingDenominator: '100000000000',
         });
         await cm.msgSend(treasury, '100000');
         const res = await cm.executeContract(
@@ -457,6 +458,7 @@ describe('Neutron / Treasury', () => {
         minPeriod: 1000,
         distributionContract: dsc,
         reserveContract: reserve,
+        vestingDenominator: '100000000000',
       });
     });
 
@@ -600,7 +602,6 @@ const normalizeTreasuryBurnedCoins = async (
 
 const getBurnedCoinsAmount = async (
   cm: CosmosWrapper,
-  denom: string,
 ): Promise<string | undefined | null> => {
   const totalBurnedNeutrons = await cm.queryTotalBurnedNeutronsAmount();
   return totalBurnedNeutrons.total_burned_neutrons_amount.coin.amount;
@@ -634,6 +635,7 @@ const setupTreasury = async (
     distributionContract: string;
     reserveContract: string;
     securityDaoAddress: string;
+    vestingDenominator: string;
   },
 ) => {
   const codeId = await cm.storeWasm(NeutronContract.TREASURY);
@@ -648,6 +650,7 @@ const setupTreasury = async (
         distribution_contract: opts.distributionContract,
         reserve_contract: opts.reserveContract,
         security_dao_address: opts.securityDaoAddress,
+        vesting_denominator: opts.vestingDenominator,
       }),
       'treausry',
     )


### PR DESCRIPTION
Treasury tokens are vested based on on-chain activity: burnt_tokens * a_multiplier. The multiplier is an linear function of the supply: while initially, one burnt tokens equals multiple NTRN tokens made liquid, the flow of new tokens into the Treasury progressively slows down until the tokens supply is exhausted and the tokenomy becomes deflationary.

Depends on:
* https://github.com/neutron-org/neutron-dao/pull/15
* https://github.com/neutron-org/neutron/pull/117