### PR TITLE
feat: add test for subDAO config update via proposal

### DIFF
--- a/src/helpers/dao.ts
+++ b/src/helpers/dao.ts
@@ -20,3 +20,11 @@ export type TimelockConfig = {
 export type TimelockProposalListResponse = {
   proposals: Array<TimeLockSingleChoiceProposal>;
 };
+
+export type SubDaoConfig = {
+  name: string;
+  description: string;
+  dao_uri: string;
+  main_dao: string;
+  security_dao: string;
+};

--- a/src/testcases/subdao.test.ts
+++ b/src/testcases/subdao.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   CosmosWrapper,
   NEUTRON_DENOM,
@@ -980,8 +981,8 @@ const executeTimelockedProposal = async (
   cm: CosmosWrapper,
   timelock_contract: string,
   proposal_id: number,
-): Promise<InlineResponse20075TxResponse> => {
-  return cm.executeContract(
+): Promise<InlineResponse20075TxResponse> =>
+  cm.executeContract(
     timelock_contract,
     JSON.stringify({
       execute_proposal: {
@@ -989,14 +990,13 @@ const executeTimelockedProposal = async (
       },
     }),
   );
-};
 
 const overruleTimelockedProposal = async (
   cm: CosmosWrapper,
   timelock_contract: string,
   proposal_id: number,
-): Promise<InlineResponse20075TxResponse> => {
-  return cm.executeContract(
+): Promise<InlineResponse20075TxResponse> =>
+  cm.executeContract(
     timelock_contract,
     JSON.stringify({
       overrule_proposal: {
@@ -1004,4 +1004,3 @@ const overruleTimelockedProposal = async (
       },
     }),
   );
-};


### PR DESCRIPTION
this PR prettifies `subdao.test.ts` and adds to it an additional test that updates subDAO config using a proposal

**contracts:** https://github.com/neutron-org/neutron-dao/pull/29
**tests result:** https://github.com/neutron-org/neutron-tests/actions/runs/3925298149.