### PR TITLE
feat: test invalid config

### DIFF
--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -387,12 +387,12 @@ export class CosmosWrapper {
     const url = `${this.sdk.url}/wasm/contract/${contract}/smart/${Buffer.from(
       JSON.stringify(query),
     ).toString('base64')}?encoding=base64`;
-    const req = await axios.get<{
+    const resp = await axios.get<{
       result: { smart: string };
       height: number;
     }>(url);
     return JSON.parse(
-      Buffer.from(req.data.result.smart, 'base64').toString(),
+      Buffer.from(resp.data.result.smart, 'base64').toString(),
     ) as T;
   }
 

--- a/src/helpers/wait.ts
+++ b/src/helpers/wait.ts
@@ -61,10 +61,11 @@ export const getWithAttempts = async <T>(
   numAttempts = 20,
 ): Promise<T> => {
   let error = null;
+  let data: T;
   while (numAttempts > 0) {
     numAttempts--;
     try {
-      const data = await getFunc();
+      data = await getFunc();
       if (await readyFunc(data)) {
         return data;
       }
@@ -73,5 +74,10 @@ export const getWithAttempts = async <T>(
     }
     await blockWaiter.waitBlocks(1);
   }
-  throw error != null ? error : new Error('getWithAttempts: no attempts left');
+  throw error != null
+    ? error
+    : new Error(
+        'getWithAttempts: no attempts left. Latest get response: ' +
+          (data === Object(data) ? JSON.stringify(data) : data).toString(),
+      );
 };

--- a/src/testcases/subdao.test.ts
+++ b/src/testcases/subdao.test.ts
@@ -126,15 +126,11 @@ describe('Neutron / Subdao', () => {
       // timelocked proposal execution failed due to insufficient funds on timelock contract
       await executeTimelockedProposal(cm, subDAO.timelock.address, proposal_id);
       // TODO: check the reason of the failure
-      const timelocked_prop =
-        await cm.queryContract<TimeLockSingleChoiceProposal>(
-          subDAO.timelock.address,
-          {
-            proposal: {
-              proposal_id: proposal_id,
-            },
-          },
-        );
+      const timelocked_prop = await getTimelockedProposal(
+        cm,
+        subDAO.timelock.address,
+        proposal_id,
+      );
       expect(timelocked_prop.id).toEqual(proposal_id);
       expect(timelocked_prop.status).toEqual('execution_failed');
       expect(timelocked_prop.msgs).toHaveLength(2);
@@ -208,15 +204,11 @@ describe('Neutron / Subdao', () => {
         ) + 2000,
       );
 
-      const timelocked_prop =
-        await cm.queryContract<TimeLockSingleChoiceProposal>(
-          subDAO.timelock.address,
-          {
-            proposal: {
-              proposal_id: proposal_id,
-            },
-          },
-        );
+      const timelocked_prop = await getTimelockedProposal(
+        cm,
+        subDAO.timelock.address,
+        proposal_id,
+      );
       expect(timelocked_prop.id).toEqual(proposal_id);
       expect(timelocked_prop.status).toEqual('executed');
       expect(timelocked_prop.msgs).toHaveLength(2);
@@ -267,15 +259,11 @@ describe('Neutron / Subdao', () => {
         subDAO.timelock.address,
         proposal_id,
       );
-      const timelocked_prop =
-        await cm.queryContract<TimeLockSingleChoiceProposal>(
-          subDAO.timelock.address,
-          {
-            proposal: {
-              proposal_id: proposal_id,
-            },
-          },
-        );
+      const timelocked_prop = await getTimelockedProposal(
+        cm,
+        subDAO.timelock.address,
+        proposal_id,
+      );
       expect(timelocked_prop.id).toEqual(proposal_id);
       expect(timelocked_prop.status).toEqual('overruled');
       expect(timelocked_prop.msgs).toHaveLength(2);
@@ -357,15 +345,11 @@ describe('Neutron / Subdao', () => {
 
       await wait(20); // wait until timelock duration passes
       await executeTimelockedProposal(cm, subDAO.timelock.address, proposal_id);
-      const timelocked_prop =
-        await cm.queryContract<TimeLockSingleChoiceProposal>(
-          subDAO.timelock.address,
-          {
-            proposal: {
-              proposal_id: proposal_id,
-            },
-          },
-        );
+      const timelocked_prop = await getTimelockedProposal(
+        cm,
+        subDAO.timelock.address,
+        proposal_id,
+      );
       expect(timelocked_prop.id).toEqual(proposal_id);
       expect(timelocked_prop.status).toEqual('executed');
       expect(timelocked_prop.msgs).toHaveLength(1);
@@ -970,16 +954,7 @@ const supportAndExecuteProposal = async (
     propose_contract,
     JSON.stringify({ execute: { proposal_id: proposal_id } }),
   );
-
-  const timelocked_prop = await cm.queryContract<TimeLockSingleChoiceProposal>(
-    timelock_contract,
-    {
-      proposal: {
-        proposal_id: proposal_id,
-      },
-    },
-  );
-  return timelocked_prop;
+  return await getTimelockedProposal(cm, timelock_contract, proposal_id);
 };
 
 const executeTimelockedProposal = async (
@@ -1009,3 +984,14 @@ const overruleTimelockedProposal = async (
       },
     }),
   );
+
+const getTimelockedProposal = async (
+  cm: CosmosWrapper,
+  timelock_contract: string,
+  proposal_id: number,
+): Promise<TimeLockSingleChoiceProposal> =>
+  cm.queryContract<TimeLockSingleChoiceProposal>(timelock_contract, {
+    proposal: {
+      proposal_id: proposal_id,
+    },
+  });


### PR DESCRIPTION
**task:** https://p2pvalidator.atlassian.net/browse/NTRN-329

**relative Neutron DAO contracts PR:** https://github.com/neutron-org/neutron-dao/pull/34

This PR:
- adds a test case for subDAO `update_config` with an empty `name` value which is supposed to be failed;
- brings a better logging for failed `getWithAttempts`: it wasn't possible to determine where exactly the failure occurred because not the logging nor the trace showed the cause, only the test where it happened in. With a little logging improvement it will be much more handy to parse such errors because of the payload it will contain;
- a little typo fix for `queryContract`.

**tests run:** https://github.com/neutron-org/neutron-tests/actions/runs/3995651043