### PR TITLE
NTRN-345 rm owner in timelock contract 

### DIFF
--- a/src/testcases/subdao.test.ts
+++ b/src/testcases/subdao.test.ts
@@ -843,7 +843,6 @@ const setupSubDaoTimelockSet = async (
                 label: 'subDAO timelock contract',
                 msg: Buffer.from(
                   JSON.stringify({
-                    owner: main_dao_addr,
                     timelock_duration: 20,
                   }),
                 ).toString('base64'),


### PR DESCRIPTION
 [TEST RUN](https://github.com/neutron-org/neutron-tests/actions/runs/4054199243/jobs/6975934929)

Currently we get the main dao address (a.k.a. “owner“) from the instantiate message. Idea of this task is to get it automatically from the subdao core (implement a query) and remove the owner field from the instantiate message.