### PR TITLE
For parallel tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:governance": "jest --runInBand -b src/testcases/governance",
     "test:subdao": "jest --runInBand -b src/testcases/subdao",
     "test:tokenomics": "jest --runInBand -b src/testcases/tokenomics",
-    "test:parallel": "jest  -b src/testcases/tokenomics.test.ts --colors -b src/testcases/simple",
+    "test:parallel": "jest  -b src/testcases/tokenomics.test.ts --colors -b src/testcases/simple -b src/testcases/treasury",
     "gen:proto": "bash ./gen-proto.sh",
     "lint": "eslint ./src",
     "fmt": "eslint ./src --fix"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "test:governance": "jest --runInBand -b src/testcases/governance",
     "test:subdao": "jest --runInBand -b src/testcases/subdao",
     "test:tokenomics": "jest --runInBand -b src/testcases/tokenomics",
-    "test:parallel": "jest  -b src/testcases/simple.test.ts -b src/testcases/tokenomics.test.ts --colors",
     "gen:proto": "bash ./gen-proto.sh",
     "lint": "eslint ./src",
     "fmt": "eslint ./src --fix"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "test:subdao": "jest --runInBand -b src/testcases/subdao",
     "test:tokenomics": "jest --runInBand -b src/testcases/tokenomics",
     "test:parallel": "jest  -b src/testcases/tokenomics.test.ts --colors -b src/testcases/simple -b src/testcases/treasury",
-    "test:testing1": "jest --runInBand -b src/testcases/testing1 - ",
-    "test:testing2": "jest -b src/testcases/testing2 -b src/testcases/testing1",
     "gen:proto": "bash ./gen-proto.sh",
     "lint": "eslint ./src",
     "fmt": "eslint ./src --fix"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:governance": "jest --runInBand -b src/testcases/governance",
     "test:subdao": "jest --runInBand -b src/testcases/subdao",
     "test:tokenomics": "jest --runInBand -b src/testcases/tokenomics",
+    "test:parallel": "jest  -b src/testcases/simple.test.ts -b src/testcases/tokenomics.test.ts --colors",
     "gen:proto": "bash ./gen-proto.sh",
     "lint": "eslint ./src",
     "fmt": "eslint ./src --fix"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:subdao": "jest --runInBand -b src/testcases/subdao",
     "test:tokenomics": "jest --runInBand -b src/testcases/tokenomics",
     "test:parallel": "jest  -b src/testcases/tokenomics.test.ts --colors -b src/testcases/simple -b src/testcases/treasury",
+    "test:testing1": "jest --runInBand -b src/testcases/testing1 - ",
+    "test:testing2": "jest -b src/testcases/testing2 -b src/testcases/testing1",
     "gen:proto": "bash ./gen-proto.sh",
     "lint": "eslint ./src",
     "fmt": "eslint ./src --fix"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:governance": "jest --runInBand -b src/testcases/governance",
     "test:subdao": "jest --runInBand -b src/testcases/subdao",
     "test:tokenomics": "jest --runInBand -b src/testcases/tokenomics",
-    "test:parallel": "jest  -b src/testcases/simple.test.ts -b src/testcases/tokenomics.test.ts --colors",
+    "test:parallel": "jest  -b src/testcases/tokenomics.test.ts --colors -b src/testcases/simple",
     "gen:proto": "bash ./gen-proto.sh",
     "lint": "eslint ./src",
     "fmt": "eslint ./src --fix"

--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -235,7 +235,7 @@ export class CosmosWrapper {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: sequence,
+          sequence,
         },
       ],
       fee,

--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -192,6 +192,9 @@ cosmosclient.codec.register(
 );
 
 export class CosmosWrapper {
+  sendTokensWithRetry(cm: CosmosWrapper, address: string, arg2: string, sequence: number) {
+    throw new Error('Method not implemented.');
+  }
   sdk: cosmosclient.CosmosSDK;
   blockWaiter: BlockWaiter;
   wallet: Wallet;
@@ -708,7 +711,9 @@ export class CosmosWrapper {
       sender,
     );
   }
-
+  async getSeq() {
+    return Number(this.wallet.account.sequence);
+  }
   /**
    * submitSoftwareUpgradeProposal creates proposal.
    */

--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -274,7 +274,6 @@ export class CosmosWrapper {
       }
     }
     error = error ?? new Error('failed to submit tx');
-    console.log(error);
     throw error;
   }
 
@@ -1233,7 +1232,7 @@ export const mnemonicToWallet = async (
   }
   return new Wallet(address, account, pubKey, privKey, addrPrefix);
 };
-export const createAddress = async (mnemonicQA?: string) => {
+export const createAddress = async (mnemonicQA: string) => {
   const privKey = new proto.cosmos.crypto.secp256k1.PrivKey({
     key: await cosmosclient.generatePrivKeyFromMnemonic(mnemonicQA),
   });

--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -192,9 +192,6 @@ cosmosclient.codec.register(
 );
 
 export class CosmosWrapper {
-  sendTokensWithRetry(cm: CosmosWrapper, address: string, arg2: string, sequence: number) {
-    throw new Error('Method not implemented.');
-  }
   sdk: cosmosclient.CosmosSDK;
   blockWaiter: BlockWaiter;
   wallet: Wallet;

--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -217,6 +217,7 @@ export class CosmosWrapper {
     msgs: T[],
     numAttempts = 10,
     mode: rest.tx.BroadcastTxMode = rest.tx.BroadcastTxMode.Async,
+    sequence: number = this.wallet.account.sequence,
   ): Promise<CosmosTxV1beta1GetTxResponse> {
     const protoMsgs: Array<google.protobuf.IAny> = [];
     msgs.forEach((msg) => {
@@ -234,7 +235,7 @@ export class CosmosWrapper {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: this.wallet.account.sequence,
+          sequence: sequence,
         },
       ],
       fee,
@@ -273,6 +274,7 @@ export class CosmosWrapper {
       }
     }
     error = error ?? new Error('failed to submit tx');
+    console.log(error);
     throw error;
   }
 
@@ -406,13 +408,20 @@ export class CosmosWrapper {
       gas_limit: Long.fromString('200000'),
       amount: [{ denom: this.denom, amount: '1000' }],
     },
+    sequence: number = this.wallet.account.sequence,
   ): Promise<InlineResponse20075TxResponse> {
     const msgSend = new proto.cosmos.bank.v1beta1.MsgSend({
       from_address: this.wallet.address.toString(),
       to_address: to,
       amount: [{ denom: this.denom, amount }],
     });
-    const res = await this.execTx(fee, [msgSend]);
+    const res = await this.execTx(
+      fee,
+      [msgSend],
+      10,
+      rest.tx.BroadcastTxMode.Block,
+      sequence,
+    );
     return res?.tx_response;
   }
 
@@ -1203,7 +1212,14 @@ export const mnemonicToWallet = async (
   }
   return new Wallet(address, account, pubKey, privKey, addrPrefix);
 };
-
+export const createAddress = async (mnemonicQA?: string) => {
+  const privKey = new proto.cosmos.crypto.secp256k1.PrivKey({
+    key: await cosmosclient.generatePrivKeyFromMnemonic(mnemonicQA),
+  });
+  const pubKey = privKey.pubKey();
+  const address = cosmosclient.AccAddress.fromPublicKey(pubKey).toString();
+  return address;
+};
 export const getSequenceId = (rawLog: string | undefined): number => {
   if (!rawLog) {
     throw 'getSequenceId: empty rawLog';

--- a/src/helpers/cosmos.ts
+++ b/src/helpers/cosmos.ts
@@ -217,7 +217,6 @@ export class CosmosWrapper {
     msgs: T[],
     numAttempts = 10,
     mode: rest.tx.BroadcastTxMode = rest.tx.BroadcastTxMode.Async,
-    sequence: number = this.wallet.account.sequence,
   ): Promise<CosmosTxV1beta1GetTxResponse> {
     const protoMsgs: Array<google.protobuf.IAny> = [];
     msgs.forEach((msg) => {
@@ -235,7 +234,7 @@ export class CosmosWrapper {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: sequence,
+          sequence: this.wallet.account.sequence,
         },
       ],
       fee,
@@ -274,7 +273,6 @@ export class CosmosWrapper {
       }
     }
     error = error ?? new Error('failed to submit tx');
-    console.log(error);
     throw error;
   }
 
@@ -408,22 +406,13 @@ export class CosmosWrapper {
       gas_limit: Long.fromString('200000'),
       amount: [{ denom: this.denom, amount: '1000' }],
     },
-    sequence: number = this.wallet.account.sequence,
   ): Promise<InlineResponse20075TxResponse> {
     const msgSend = new proto.cosmos.bank.v1beta1.MsgSend({
       from_address: this.wallet.address.toString(),
       to_address: to,
       amount: [{ denom: this.denom, amount }],
     });
-    console.log('sequence in msgSend from test');
-    console.log(sequence);
-    const res = await this.execTx(
-      fee,
-      [msgSend],
-      10,
-      rest.tx.BroadcastTxMode.Block,
-      sequence,
-    );
+    const res = await this.execTx(fee, [msgSend]);
     return res?.tx_response;
   }
 
@@ -1214,16 +1203,7 @@ export const mnemonicToWallet = async (
   }
   return new Wallet(address, account, pubKey, privKey, addrPrefix);
 };
-export const createAddress = async (mnemonicQA?: string) => {
-  const privKey = new proto.cosmos.crypto.secp256k1.PrivKey({
-    key: await cosmosclient.generatePrivKeyFromMnemonic(mnemonicQA),
-  });
-  console.log('this is mnemonic from neutron');
-  console.log(mnemonicQA);
-  const pubKey = privKey.pubKey();
-  const address = cosmosclient.AccAddress.fromPublicKey(pubKey).toString();
-  return address;
-};
+
 export const getSequenceId = (rawLog: string | undefined): number => {
   if (!rawLog) {
     throw 'getSequenceId: empty rawLog';

--- a/src/testcases/common_localcosmosnet.ts
+++ b/src/testcases/common_localcosmosnet.ts
@@ -104,6 +104,9 @@ export class TestStateLocalCosmosTestNet {
     await setup(host1, host2);
     const mnemonicQA = generateMnemonic();
     const mnemonicQATwo = generateMnemonic();
+    const mnemonicQAThree = generateMnemonic();
+    const mnemonicQAFour = generateMnemonic();
+    const mnemonicQAFive = generateMnemonic();
 
     this.wallets = {};
     this.wallets.neutron = await walletSet(this.sdk1, neutronPrefix);
@@ -127,16 +130,58 @@ export class TestStateLocalCosmosTestNet {
       COSMOS_DENOM,
       this.wallets.cosmos.demo2.address,
     );
+    await this.createQaWallet(
+      mnemonicQAThree,
+      neutronPrefix,
+      this.sdk1,
+      this.blockWaiter1,
+      this.wallets.neutron.demo1,
+      NEUTRON_DENOM,
+      this.wallets.neutron.demo1.address,
+    );
+    await this.createQaWallet(
+      mnemonicQAFour,
+      neutronPrefix,
+      this.sdk1,
+      this.blockWaiter1,
+      this.wallets.neutron.demo1,
+      NEUTRON_DENOM,
+      this.wallets.neutron.demo1.address,
+    );
+    await this.createQaWallet(
+      mnemonicQAFive,
+      neutronPrefix,
+      this.sdk1,
+      this.blockWaiter1,
+      this.wallets.neutron.demo1,
+      NEUTRON_DENOM,
+      this.wallets.neutron.demo1.address,
+    );
 
-    this.wallets.qaOne = await walletSetQa(
+    this.wallets.qaNeutron = await walletSetQa(
       this.sdk1,
       neutronPrefix,
       mnemonicQA,
     );
-    this.wallets.qaTwo = await walletSetQa(
+    this.wallets.qaCosmos = await walletSetQa(
       this.sdk2,
       cosmosPrefix,
       mnemonicQATwo,
+    );
+    this.wallets.qaNeutronThree = await walletSetQa(
+      this.sdk1,
+      neutronPrefix,
+      mnemonicQAThree,
+    );
+    this.wallets.qaNeutronFour = await walletSetQa(
+      this.sdk1,
+      neutronPrefix,
+      mnemonicQAFour,
+    );
+    this.wallets.qaNeutronFive = await walletSetQa(
+      this.sdk1,
+      neutronPrefix,
+      mnemonicQAFive,
     );
   };
   sendTokensWithRetry = async (
@@ -189,11 +234,10 @@ export class TestStateLocalCosmosTestNet {
 
     const address = await createAddress(mnemonic);
     const sequence = await cm.getSeq(sdk, walletAddress);
-    await cm.blockWaiter.waitBlocks(1);
     await this.sendTokensWithRetry(
       cm,
       toString(address),
-      '5500000000',
+      '10500000000',
       sequence,
     );
     const balances = await cm.queryBalances(toString(address));

--- a/src/testcases/common_localcosmosnet.ts
+++ b/src/testcases/common_localcosmosnet.ts
@@ -1,9 +1,16 @@
 import { exec } from 'child_process';
 import { cosmosclient } from '@cosmos-client/core';
 import { Wallet } from '../types';
-import { mnemonicToWallet } from '../helpers/cosmos';
+import {
+  COSMOS_DENOM,
+  createAddress,
+  mnemonicToWallet,
+} from '../helpers/cosmos';
 import { setup } from '../helpers/env';
 import { BlockWaiter } from '../helpers/wait';
+import { generateMnemonic } from 'bip39';
+import { CosmosWrapper, NEUTRON_DENOM } from '../helpers/cosmos';
+import Long from 'long';
 
 const config = require('../config.json');
 
@@ -53,6 +60,30 @@ const walletSet = async (
     prefix,
   ),
 });
+const walletSetQa = async (
+  sdk: cosmosclient.CosmosSDK,
+  prefix: string,
+  mnemonicQA: string,
+): Promise<Record<string, Wallet>> => ({
+  demo1: await mnemonicToWallet(
+    cosmosclient.AccAddress,
+    sdk,
+    mnemonicQA,
+    prefix,
+  ),
+});
+const walletSetQaTwo = async (
+  sdk: cosmosclient.CosmosSDK,
+  prefix: string,
+  mnemonicQATwo: string,
+): Promise<Record<string, Wallet>> => ({
+  demo2: await mnemonicToWallet(
+    cosmosclient.AccAddress,
+    sdk,
+    mnemonicQATwo,
+    prefix,
+  ),
+});
 
 export class TestStateLocalCosmosTestNet {
   sdk1: cosmosclient.CosmosSDK;
@@ -62,8 +93,8 @@ export class TestStateLocalCosmosTestNet {
   wallets: Record<string, Record<string, Wallet>>;
   icq_web_host: string;
   init = async () => {
-    const neutron_prefix = process.env.NEUTRON_ADDRESS_PREFIX || 'neutron';
-    const cosmos_prefix = process.env.COSMOS_ADDRESS_PREFIX || 'cosmos';
+    const neutronPrefix = process.env.NEUTRON_ADDRESS_PREFIX || 'neutron';
+    const cosmosPrefix = process.env.COSMOS_ADDRESS_PREFIX || 'cosmos';
 
     const host1 = process.env.NODE1_URL || 'http://localhost:1317';
     const host2 = process.env.NODE2_URL || 'http://localhost:1316';
@@ -81,9 +112,111 @@ export class TestStateLocalCosmosTestNet {
     );
 
     await setup(host1, host2);
+    const mnemonicQA = generateMnemonic();
+    const mnemonicQATwo = generateMnemonic();
+    await this.createQaWallet(mnemonicQA, neutronPrefix);
+    await this.createQaWalletTwo(mnemonicQATwo, cosmosPrefix);
 
     this.wallets = {};
-    this.wallets.neutron = await walletSet(this.sdk1, neutron_prefix);
-    this.wallets.cosmos = await walletSet(this.sdk2, cosmos_prefix);
+    this.wallets.neutron = await walletSet(this.sdk1, neutronPrefix);
+    this.wallets.cosmos = await walletSet(this.sdk2, cosmosPrefix);
+    this.wallets.qaOne = await walletSetQa(
+      this.sdk1,
+      neutronPrefix,
+      mnemonicQA,
+    );
+    this.wallets.qaTwo = await walletSetQaTwo(
+      this.sdk2,
+      cosmosPrefix,
+      mnemonicQATwo,
+    );
+  };
+
+  createQaWallet = async (mnemonicQA?: string, neutronPrefix?: string) => {
+    const tmpWallet = await mnemonicToWallet(
+      cosmosclient.AccAddress,
+      this.sdk1,
+      config.DEMO_MNEMONIC_1,
+      neutronPrefix,
+    );
+    console.log('This is first wallet');
+
+    const cm = new CosmosWrapper(
+      this.sdk1,
+      this.blockWaiter1,
+      tmpWallet,
+      NEUTRON_DENOM,
+    );
+
+    cosmosclient.config.setBech32Prefix({
+      accAddr: neutronPrefix,
+      accPub: `${neutronPrefix}pub`,
+      valAddr: `${neutronPrefix}valoper`,
+      valPub: `${neutronPrefix}valoperpub`,
+      consAddr: `${neutronPrefix}valcons`,
+      consPub: `${neutronPrefix}valconspub`,
+    });
+    const address = await createAddress(mnemonicQA);
+    try {
+      await cm.msgSend(address, '4300000000');
+    } catch (e) {
+      const sequenceTry = tmpWallet.account.sequence;
+      await cm.msgSend(
+        address,
+        '3000000000',
+        {
+          gas_limit: Long.fromString('200000'),
+          amount: [{ denom: cm.denom, amount: '15000' }],
+        },
+        Number(sequenceTry) + 1,
+      );
+    }
+    const balances = await cm.queryBalances(address);
+    if (balances == null) {
+      throw new Error('Could not  put tokens on the generated wallet.');
+    }
+    console.log(balances);
+  };
+  createQaWalletTwo = async (mnemonicQATwo?: string, cosmosPrefix?: string) => {
+    const tmpWalletTwo = await mnemonicToWallet(
+      cosmosclient.AccAddress,
+      this.sdk2,
+      config.DEMO_MNEMONIC_2,
+      cosmosPrefix,
+    );
+    const cm2 = new CosmosWrapper(
+      this.sdk2,
+      this.blockWaiter2,
+      tmpWalletTwo,
+      COSMOS_DENOM,
+    );
+    cosmosclient.config.setBech32Prefix({
+      accAddr: cosmosPrefix,
+      accPub: `${cosmosPrefix}pub`,
+      valAddr: `${cosmosPrefix}valoper`,
+      valPub: `${cosmosPrefix}valoperpub`,
+      consAddr: `${cosmosPrefix}valcons`,
+      consPub: `${cosmosPrefix}valconspub`,
+    });
+    const address = await createAddress(mnemonicQATwo);
+    try {
+      await cm2.msgSend(address, '4300000000');
+    } catch (e) {
+      const sequenceTry = tmpWalletTwo.account.sequence++;
+      await cm2.msgSend(
+        address,
+        '3000000000',
+        {
+          gas_limit: Long.fromString('200000'),
+          amount: [{ denom: cm2.denom, amount: '15000' }],
+        },
+        Number(sequenceTry) + 1,
+      );
+    }
+    const balances = await cm2.queryBalances(address);
+    if (balances == null) {
+      throw new Error('Could not  put tokens on the generated wallet.');
+    }
+    console.log(balances);
   };
 }

--- a/src/testcases/common_localcosmosnet.ts
+++ b/src/testcases/common_localcosmosnet.ts
@@ -1,9 +1,16 @@
 import { exec } from 'child_process';
 import { cosmosclient } from '@cosmos-client/core';
 import { Wallet } from '../types';
-import { mnemonicToWallet } from '../helpers/cosmos';
+import {
+  COSMOS_DENOM,
+  createAddress,
+  mnemonicToWallet,
+} from '../helpers/cosmos';
 import { setup } from '../helpers/env';
 import { BlockWaiter } from '../helpers/wait';
+import { generateMnemonic } from 'bip39';
+import { CosmosWrapper, NEUTRON_DENOM } from '../helpers/cosmos';
+import Long from 'long';
 
 const config = require('../config.json');
 
@@ -53,6 +60,30 @@ const walletSet = async (
     prefix,
   ),
 });
+const walletSetQa = async (
+  sdk: cosmosclient.CosmosSDK,
+  prefix: string,
+  mnemonicQA: string,
+): Promise<Record<string, Wallet>> => ({
+  demo1: await mnemonicToWallet(
+    cosmosclient.AccAddress,
+    sdk,
+    mnemonicQA,
+    prefix,
+  ),
+});
+const walletSetQaTwo = async (
+  sdk: cosmosclient.CosmosSDK,
+  prefix: string,
+  mnemonicQATwo: string,
+): Promise<Record<string, Wallet>> => ({
+  demo2: await mnemonicToWallet(
+    cosmosclient.AccAddress,
+    sdk,
+    mnemonicQATwo,
+    prefix,
+  ),
+});
 
 export class TestStateLocalCosmosTestNet {
   sdk1: cosmosclient.CosmosSDK;
@@ -62,8 +93,8 @@ export class TestStateLocalCosmosTestNet {
   wallets: Record<string, Record<string, Wallet>>;
   icq_web_host: string;
   init = async () => {
-    const neutron_prefix = process.env.NEUTRON_ADDRESS_PREFIX || 'neutron';
-    const cosmos_prefix = process.env.COSMOS_ADDRESS_PREFIX || 'cosmos';
+    const neutronPrefix = process.env.NEUTRON_ADDRESS_PREFIX || 'neutron';
+    const cosmosPrefix = process.env.COSMOS_ADDRESS_PREFIX || 'cosmos';
 
     const host1 = process.env.NODE1_URL || 'http://localhost:1317';
     const host2 = process.env.NODE2_URL || 'http://localhost:1316';
@@ -81,9 +112,111 @@ export class TestStateLocalCosmosTestNet {
     );
 
     await setup(host1, host2);
+    const mnemonicQA = generateMnemonic();
+    const mnemonicQATwo = generateMnemonic();
+    await this.createQaWallet(mnemonicQA, neutronPrefix);
+    await this.createQaWalletTwo(mnemonicQATwo, cosmosPrefix);
 
     this.wallets = {};
-    this.wallets.neutron = await walletSet(this.sdk1, neutron_prefix);
-    this.wallets.cosmos = await walletSet(this.sdk2, cosmos_prefix);
+    this.wallets.neutron = await walletSet(this.sdk1, neutronPrefix);
+    this.wallets.cosmos = await walletSet(this.sdk2, cosmosPrefix);
+    this.wallets.qaOne = await walletSetQa(
+      this.sdk1,
+      neutronPrefix,
+      mnemonicQA,
+    );
+    this.wallets.qaTwo = await walletSetQaTwo(
+      this.sdk2,
+      cosmosPrefix,
+      mnemonicQATwo,
+    );
+  };
+
+  createQaWallet = async (mnemonicQA?: string, neutronPrefix?: string) => {
+    const tmpWallet = await mnemonicToWallet(
+      cosmosclient.AccAddress,
+      this.sdk1,
+      config.DEMO_MNEMONIC_1,
+      neutronPrefix,
+    );
+    console.log('This is first wallet');
+
+    const cm = new CosmosWrapper(
+      this.sdk1,
+      this.blockWaiter1,
+      tmpWallet,
+      NEUTRON_DENOM,
+    );
+
+    cosmosclient.config.setBech32Prefix({
+      accAddr: neutronPrefix,
+      accPub: `${neutronPrefix}pub`,
+      valAddr: `${neutronPrefix}valoper`,
+      valPub: `${neutronPrefix}valoperpub`,
+      consAddr: `${neutronPrefix}valcons`,
+      consPub: `${neutronPrefix}valconspub`,
+    });
+    const address = await createAddress(mnemonicQA);
+    try {
+      await cm.msgSend(address, '3000000000');
+    } catch (e) {
+      const sequenceTry = tmpWallet.account.sequence;
+      await cm.msgSend(
+        address,
+        '3000000000',
+        {
+          gas_limit: Long.fromString('400000'),
+          amount: [{ denom: cm.denom, amount: '1000' }],
+        },
+        Number(sequenceTry) + 1,
+      );
+    }
+    const balances = await cm.queryBalances(address);
+    if (balances == null) {
+      throw new Error('Could not  put tokens on the generated wallet.');
+    }
+    console.log(balances);
+  };
+  createQaWalletTwo = async (mnemonicQATwo?: string, cosmosPrefix?: string) => {
+    const tmpWalletTwo = await mnemonicToWallet(
+      cosmosclient.AccAddress,
+      this.sdk2,
+      config.DEMO_MNEMONIC_2,
+      cosmosPrefix,
+    );
+    const cm2 = new CosmosWrapper(
+      this.sdk2,
+      this.blockWaiter2,
+      tmpWalletTwo,
+      COSMOS_DENOM,
+    );
+    cosmosclient.config.setBech32Prefix({
+      accAddr: cosmosPrefix,
+      accPub: `${cosmosPrefix}pub`,
+      valAddr: `${cosmosPrefix}valoper`,
+      valPub: `${cosmosPrefix}valoperpub`,
+      consAddr: `${cosmosPrefix}valcons`,
+      consPub: `${cosmosPrefix}valconspub`,
+    });
+    const address = await createAddress(mnemonicQATwo);
+    try {
+      await cm2.msgSend(address, '3000000000');
+    } catch (e) {
+      const sequenceTry = tmpWalletTwo.account.sequence++;
+      await cm2.msgSend(
+        address,
+        '3000000000',
+        {
+          gas_limit: Long.fromString('400000'),
+          amount: [{ denom: cm2.denom, amount: '1000' }],
+        },
+        Number(sequenceTry) + 1,
+      );
+    }
+    const balances = await cm2.queryBalances(address);
+    if (balances == null) {
+      throw new Error('Could not  put tokens on the generated wallet.');
+    }
+    console.log(balances);
   };
 }

--- a/src/testcases/common_localcosmosnet.ts
+++ b/src/testcases/common_localcosmosnet.ts
@@ -157,8 +157,9 @@ export class TestStateLocalCosmosTestNet {
         await cm.msgSend(to, amount, fee, sequence);
         return;
       } catch (e) {
+        await cm.blockWaiter.waitBlocks(1);
         retryCount++;
-        sequence++;
+        sequence = await cm.getSeq(cm.sdk, cm.wallet.address);
         if (retryCount === 4) {
           throw new Error(`Failed to send tokens after ${retryCount} retries.`);
         }
@@ -188,7 +189,7 @@ export class TestStateLocalCosmosTestNet {
 
     const address = await createAddress(mnemonic);
     const sequence = await cm.getSeq(sdk, walletAddress);
-    await blockWaiter.waitBlocks(1);
+    await cm.blockWaiter.waitBlocks(1);
     await this.sendTokensWithRetry(
       cm,
       toString(address),

--- a/src/testcases/common_localcosmosnet.ts
+++ b/src/testcases/common_localcosmosnet.ts
@@ -157,38 +157,38 @@ export class TestStateLocalCosmosTestNet {
       NEUTRON_DENOM,
       this.wallets.neutron.demo1.address,
     );
-
-    this.wallets.qaNeutron = await walletSetQa(
-      this.sdk1,
-      neutronPrefix,
-      mnemonicQA,
-    );
-    this.wallets.qaCosmos = await walletSetQa(
-      this.sdk2,
-      cosmosPrefix,
-      mnemonicQATwo,
-    );
-    this.wallets.qaNeutronThree = await walletSetQa(
-      this.sdk1,
-      neutronPrefix,
-      mnemonicQAThree,
-    );
-    this.wallets.qaNeutronFour = await walletSetQa(
-      this.sdk1,
-      neutronPrefix,
-      mnemonicQAFour,
-    );
-    this.wallets.qaNeutronFive = await walletSetQa(
-      this.sdk1,
-      neutronPrefix,
-      mnemonicQAFive,
-    );
+    // this.wallets.qaNeutron = await walletSetQa(
+    //   this.sdk1,
+    //   neutronPrefix,
+    //   mnemonicQA,
+    // );
+    // this.wallets.qaCosmos = await walletSetQa(
+    //   this.sdk2,
+    //   cosmosPrefix,
+    //   mnemonicQATwo,
+    // );
+    // this.wallets.qaNeutronThree = await walletSetQa(
+    //   this.sdk1,
+    //   neutronPrefix,
+    //   mnemonicQAThree,
+    // );
+    // this.wallets.qaNeutronFour = await walletSetQa(
+    //   this.sdk1,
+    //   neutronPrefix,
+    //   mnemonicQAFour,
+    // );
+    // this.wallets.qaNeutronFive = await walletSetQa(
+    //   this.sdk1,
+    //   neutronPrefix,
+    //   mnemonicQAFive,
+    // );
   };
   sendTokensWithRetry = async (
     cm: CosmosWrapper,
     to: string,
     amount: string,
     startingSequence: number,
+    address: AccAddress,
   ) => {
     const fee = {
       gas_limit: Long.fromString('200000'),
@@ -205,11 +205,13 @@ export class TestStateLocalCosmosTestNet {
         await cm.blockWaiter.waitBlocks(1);
         retryCount++;
         sequence = await cm.getSeq(cm.sdk, cm.wallet.address);
-        if (retryCount === 4) {
-          throw new Error(`Failed to send tokens after ${retryCount} retries.`);
-        }
       }
     }
+    const balances = await cm.queryBalances(toString(address));
+    if (balances == null) {
+      throw new Error('Could not put tokens on the generated wallet.');
+    }
+    throw new Error(`Failed to send tokens after ${retryCount} retries.`);
   };
 
   createQaWallet = async (
@@ -239,10 +241,7 @@ export class TestStateLocalCosmosTestNet {
       toString(address),
       '10500000000',
       sequence,
+      address,
     );
-    const balances = await cm.queryBalances(toString(address));
-    if (balances == null) {
-      throw new Error('Could not put tokens on the generated wallet.');
-    }
   };
 }

--- a/src/testcases/common_localcosmosnet.ts
+++ b/src/testcases/common_localcosmosnet.ts
@@ -157,31 +157,31 @@ export class TestStateLocalCosmosTestNet {
       NEUTRON_DENOM,
       this.wallets.neutron.demo1.address,
     );
-    // this.wallets.qaNeutron = await walletSetQa(
-    //   this.sdk1,
-    //   neutronPrefix,
-    //   mnemonicQA,
-    // );
-    // this.wallets.qaCosmos = await walletSetQa(
-    //   this.sdk2,
-    //   cosmosPrefix,
-    //   mnemonicQATwo,
-    // );
-    // this.wallets.qaNeutronThree = await walletSetQa(
-    //   this.sdk1,
-    //   neutronPrefix,
-    //   mnemonicQAThree,
-    // );
-    // this.wallets.qaNeutronFour = await walletSetQa(
-    //   this.sdk1,
-    //   neutronPrefix,
-    //   mnemonicQAFour,
-    // );
-    // this.wallets.qaNeutronFive = await walletSetQa(
-    //   this.sdk1,
-    //   neutronPrefix,
-    //   mnemonicQAFive,
-    // );
+    this.wallets.qaNeutron = await walletSetQa(
+      this.sdk1,
+      neutronPrefix,
+      mnemonicQA,
+    );
+    this.wallets.qaCosmos = await walletSetQa(
+      this.sdk2,
+      cosmosPrefix,
+      mnemonicQATwo,
+    );
+    this.wallets.qaNeutronThree = await walletSetQa(
+      this.sdk1,
+      neutronPrefix,
+      mnemonicQAThree,
+    );
+    this.wallets.qaNeutronFour = await walletSetQa(
+      this.sdk1,
+      neutronPrefix,
+      mnemonicQAFour,
+    );
+    this.wallets.qaNeutronFive = await walletSetQa(
+      this.sdk1,
+      neutronPrefix,
+      mnemonicQAFive,
+    );
   };
   sendTokensWithRetry = async (
     cm: CosmosWrapper,

--- a/src/testcases/common_localcosmosnet.ts
+++ b/src/testcases/common_localcosmosnet.ts
@@ -132,7 +132,7 @@ export class TestStateLocalCosmosTestNet {
     );
   };
 
-  createQaWallet = async (mnemonicQA?: string, neutronPrefix?: string) => {
+  createQaWallet = async (mnemonicQA: string, neutronPrefix: string) => {
     const tmpWallet = await mnemonicToWallet(
       cosmosclient.AccAddress,
       this.sdk1,
@@ -158,7 +158,7 @@ export class TestStateLocalCosmosTestNet {
     });
     const address = await createAddress(mnemonicQA);
     try {
-      await cm.msgSend(address, '4300000000');
+      await cm.msgSend(address, '5500000000');
     } catch (e) {
       const sequenceTry = tmpWallet.account.sequence;
       await cm.msgSend(
@@ -177,7 +177,7 @@ export class TestStateLocalCosmosTestNet {
     }
     console.log(balances);
   };
-  createQaWalletTwo = async (mnemonicQATwo?: string, cosmosPrefix?: string) => {
+  createQaWalletTwo = async (mnemonicQATwo: string, cosmosPrefix: string) => {
     const tmpWalletTwo = await mnemonicToWallet(
       cosmosclient.AccAddress,
       this.sdk2,
@@ -200,7 +200,7 @@ export class TestStateLocalCosmosTestNet {
     });
     const address = await createAddress(mnemonicQATwo);
     try {
-      await cm2.msgSend(address, '4300000000');
+      await cm2.msgSend(address, '5500000000');
     } catch (e) {
       const sequenceTry = tmpWalletTwo.account.sequence++;
       await cm2.msgSend(

--- a/src/testcases/common_localcosmosnet.ts
+++ b/src/testcases/common_localcosmosnet.ts
@@ -11,7 +11,6 @@ import { BlockWaiter } from '../helpers/wait';
 import { generateMnemonic } from 'bip39';
 import { CosmosWrapper, NEUTRON_DENOM } from '../helpers/cosmos';
 import Long from 'long';
-import { codecMaps } from '@cosmos-client/core/cjs/config/module';
 
 const config = require('../config.json');
 
@@ -115,7 +114,6 @@ export class TestStateLocalCosmosTestNet {
       this.blockWaiter1,
       this.wallets.neutron.demo1,
       NEUTRON_DENOM,
-      this.wallets.neutron.demo1.account.sequence,
     );
     await this.createQaWallet(
       mnemonicQATwo,
@@ -124,7 +122,6 @@ export class TestStateLocalCosmosTestNet {
       this.blockWaiter2,
       this.wallets.cosmos.demo2,
       COSMOS_DENOM,
-      this.wallets.cosmos.demo2.account.sequence,
     );
 
     this.wallets.qaOne = await walletSetQa(

--- a/src/testcases/interchain_tx_query_resubmit.test.ts
+++ b/src/testcases/interchain_tx_query_resubmit.test.ts
@@ -22,13 +22,13 @@ describe('Neutron / Interchain TX Query Resubmit', () => {
     cm = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.neutron.demo1,
+      testState.wallets.qaNeutron.genQaWal1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.cosmos.demo2,
+      testState.wallets.qaCosmos.genQaWal1,
       COSMOS_DENOM,
     );
   });

--- a/src/testcases/interchaintx.test.ts
+++ b/src/testcases/interchaintx.test.ts
@@ -32,13 +32,13 @@ describe('Neutron / Interchain TXs', () => {
     cm1 = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.neutron.demo1,
+      testState.wallets.qaNeutron.genQaWal1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.cosmos.demo2,
+      testState.wallets.qaCosmos.genQaWal1,
       COSMOS_DENOM,
     );
   });

--- a/src/testcases/interchaintx.test.ts
+++ b/src/testcases/interchaintx.test.ts
@@ -32,13 +32,13 @@ describe('Neutron / Interchain TXs', () => {
     cm1 = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.neutron.demo1,
+      testState.wallets.qaOne.genQaWal1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.cosmos.demo2,
+      testState.wallets.qaTwo.genQaWal1,
       COSMOS_DENOM,
     );
   });

--- a/src/testcases/interchaintx.test.ts
+++ b/src/testcases/interchaintx.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../helpers/cosmos';
 import { AcknowledgementResult } from '../helpers/contract_types';
 import { TestStateLocalCosmosTestNet } from './common_localcosmosnet';
-import { getWithAttempts } from '../helpers/wait';
+import { getWithAttempts, wait } from '../helpers/wait';
 import { CosmosSDK } from '@cosmos-client/core/cjs/sdk';
 import { getIca } from '../helpers/ica';
 

--- a/src/testcases/interchaintx.test.ts
+++ b/src/testcases/interchaintx.test.ts
@@ -32,13 +32,13 @@ describe('Neutron / Interchain TXs', () => {
     cm1 = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.qaOne.genQaWal1,
+      testState.wallets.neutron.demo1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.qaTwo.genQaWal1,
+      testState.wallets.cosmos.demo2,
       COSMOS_DENOM,
     );
   });

--- a/src/testcases/interchaintx.test.ts
+++ b/src/testcases/interchaintx.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../helpers/cosmos';
 import { AcknowledgementResult } from '../helpers/contract_types';
 import { TestStateLocalCosmosTestNet } from './common_localcosmosnet';
-import { getWithAttempts, wait } from '../helpers/wait';
+import { getWithAttempts } from '../helpers/wait';
 import { CosmosSDK } from '@cosmos-client/core/cjs/sdk';
 import { getIca } from '../helpers/ica';
 

--- a/src/testcases/simple.test.ts
+++ b/src/testcases/simple.test.ts
@@ -24,13 +24,13 @@ describe('Neutron / Simple', () => {
     cm = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.qaOne.demo1,
+      testState.wallets.neutron.demo1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.qaTwo.demo2,
+      testState.wallets.cosmos.demo2,
       COSMOS_DENOM,
     );
   });
@@ -85,7 +85,7 @@ describe('Neutron / Simple', () => {
           'transfer',
           'channel-0',
           { denom: NEUTRON_DENOM, amount: '1000' },
-          testState.wallets.qaTwo.demo2.address.toString(),
+          testState.wallets.cosmos.demo2.address.toString(),
           {
             revision_number: new Long(2),
             revision_height: new Long(100000000),
@@ -96,7 +96,7 @@ describe('Neutron / Simple', () => {
       test('check IBC token balance', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm2.queryBalances(
-          testState.wallets.qaTwo.demo2.address.toString(),
+          testState.wallets.cosmos.demo2.address.toString(),
         );
         expect(
           balances.balances.find(
@@ -111,7 +111,7 @@ describe('Neutron / Simple', () => {
           'transfer',
           'channel-0',
           { denom: COSMOS_DENOM, amount: '1000' },
-          testState.wallets.qaOne.demo1.address.toString(),
+          testState.wallets.neutron.demo1.address.toString(),
           {
             revision_number: new Long(2),
             revision_height: new Long(100000000),
@@ -122,7 +122,7 @@ describe('Neutron / Simple', () => {
       test('check uatom token balance transfered  via IBC on Neutron', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm.queryBalances(
-          testState.wallets.qaOne.demo1.address.toString(),
+          testState.wallets.neutron.demo1.address.toString(),
         );
         expect(
           balances.balances.find(
@@ -159,7 +159,7 @@ describe('Neutron / Simple', () => {
           JSON.stringify({
             send: {
               channel: 'channel-0',
-              to: testState.wallets.qaTwo.demo2.address.toString(),
+              to: testState.wallets.cosmos.demo2.address.toString(),
               denom: NEUTRON_DENOM,
               amount: '1000',
             },
@@ -171,7 +171,7 @@ describe('Neutron / Simple', () => {
       test('check wallet balance', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm2.queryBalances(
-          testState.wallets.qaTwo.demo2.address.toString(),
+          testState.wallets.cosmos.demo2.address.toString(),
         );
         // we expect X4 balance because the contract sends 2 txs: first one = amount and the second one amount*2 + transfer from a usual account
         expect(
@@ -223,7 +223,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.qaTwo.demo2.address.toString(),
+                to: testState.wallets.cosmos.demo2.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -280,7 +280,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.qaTwo.demo2.address.toString(),
+                to: testState.wallets.cosmos.demo2.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -310,7 +310,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.qaTwo.demo2.address.toString(),
+                to: testState.wallets.cosmos.demo2.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -351,7 +351,7 @@ describe('Neutron / Simple', () => {
           JSON.stringify({
             send: {
               channel: 'channel-0',
-              to: testState.wallets.qaTwo.demo2.address.toString(),
+              to: testState.wallets.cosmos.demo2.address.toString(),
               denom: NEUTRON_DENOM,
               amount: '1000',
             },
@@ -375,7 +375,7 @@ describe('Neutron / Simple', () => {
               JSON.stringify({
                 send: {
                   channel: 'channel-0',
-                  to: testState.wallets.qaTwo.demo2.address.toString(),
+                  to: testState.wallets.cosmos.demo2.address.toString(),
                   denom: NEUTRON_DENOM,
                   amount: '1000',
                   timeout_height: currentHeight + 2,

--- a/src/testcases/simple.test.ts
+++ b/src/testcases/simple.test.ts
@@ -24,13 +24,13 @@ describe('Neutron / Simple', () => {
     cm = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.neutron.demo1,
+      testState.wallets.qaOne.demo1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.cosmos.demo2,
+      testState.wallets.qaTwo.demo2,
       COSMOS_DENOM,
     );
   });
@@ -85,7 +85,7 @@ describe('Neutron / Simple', () => {
           'transfer',
           'channel-0',
           { denom: NEUTRON_DENOM, amount: '1000' },
-          testState.wallets.cosmos.demo2.address.toString(),
+          testState.wallets.qaTwo.demo2.address.toString(),
           {
             revision_number: new Long(2),
             revision_height: new Long(100000000),
@@ -96,7 +96,7 @@ describe('Neutron / Simple', () => {
       test('check IBC token balance', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm2.queryBalances(
-          testState.wallets.cosmos.demo2.address.toString(),
+          testState.wallets.qaTwo.demo2.address.toString(),
         );
         expect(
           balances.balances.find(
@@ -111,7 +111,7 @@ describe('Neutron / Simple', () => {
           'transfer',
           'channel-0',
           { denom: COSMOS_DENOM, amount: '1000' },
-          testState.wallets.neutron.demo1.address.toString(),
+          testState.wallets.qaOne.demo1.address.toString(),
           {
             revision_number: new Long(2),
             revision_height: new Long(100000000),
@@ -122,7 +122,7 @@ describe('Neutron / Simple', () => {
       test('check uatom token balance transfered  via IBC on Neutron', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm.queryBalances(
-          testState.wallets.neutron.demo1.address.toString(),
+          testState.wallets.qaOne.demo1.address.toString(),
         );
         expect(
           balances.balances.find(
@@ -159,7 +159,7 @@ describe('Neutron / Simple', () => {
           JSON.stringify({
             send: {
               channel: 'channel-0',
-              to: testState.wallets.cosmos.demo2.address.toString(),
+              to: testState.wallets.qaTwo.demo2.address.toString(),
               denom: NEUTRON_DENOM,
               amount: '1000',
             },
@@ -171,7 +171,7 @@ describe('Neutron / Simple', () => {
       test('check wallet balance', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm2.queryBalances(
-          testState.wallets.cosmos.demo2.address.toString(),
+          testState.wallets.qaTwo.demo2.address.toString(),
         );
         // we expect X4 balance because the contract sends 2 txs: first one = amount and the second one amount*2 + transfer from a usual account
         expect(
@@ -223,7 +223,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.cosmos.demo2.address.toString(),
+                to: testState.wallets.qaTwo.demo2.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -280,7 +280,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.cosmos.demo2.address.toString(),
+                to: testState.wallets.qaTwo.demo2.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -310,7 +310,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.cosmos.demo2.address.toString(),
+                to: testState.wallets.qaTwo.demo2.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -351,7 +351,7 @@ describe('Neutron / Simple', () => {
           JSON.stringify({
             send: {
               channel: 'channel-0',
-              to: testState.wallets.cosmos.demo2.address.toString(),
+              to: testState.wallets.qaTwo.demo2.address.toString(),
               denom: NEUTRON_DENOM,
               amount: '1000',
             },
@@ -375,7 +375,7 @@ describe('Neutron / Simple', () => {
               JSON.stringify({
                 send: {
                   channel: 'channel-0',
-                  to: testState.wallets.cosmos.demo2.address.toString(),
+                  to: testState.wallets.qaTwo.demo2.address.toString(),
                   denom: NEUTRON_DENOM,
                   amount: '1000',
                   timeout_height: currentHeight + 2,

--- a/src/testcases/simple.test.ts
+++ b/src/testcases/simple.test.ts
@@ -24,13 +24,13 @@ describe('Neutron / Simple', () => {
     cm = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.qaOne.demo1,
+      testState.wallets.qaOne.genQaWal1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.qaTwo.demo2,
+      testState.wallets.qaTwo.genQaWal1,
       COSMOS_DENOM,
     );
   });
@@ -85,7 +85,7 @@ describe('Neutron / Simple', () => {
           'transfer',
           'channel-0',
           { denom: NEUTRON_DENOM, amount: '1000' },
-          testState.wallets.qaTwo.demo2.address.toString(),
+          testState.wallets.qaTwo.genQaWal1.address.toString(),
           {
             revision_number: new Long(2),
             revision_height: new Long(100000000),
@@ -96,7 +96,7 @@ describe('Neutron / Simple', () => {
       test('check IBC token balance', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm2.queryBalances(
-          testState.wallets.qaTwo.demo2.address.toString(),
+          testState.wallets.qaTwo.genQaWal1.address.toString(),
         );
         expect(
           balances.balances.find(
@@ -111,7 +111,7 @@ describe('Neutron / Simple', () => {
           'transfer',
           'channel-0',
           { denom: COSMOS_DENOM, amount: '1000' },
-          testState.wallets.qaOne.demo1.address.toString(),
+          testState.wallets.qaOne.genQaWal1.address.toString(),
           {
             revision_number: new Long(2),
             revision_height: new Long(100000000),
@@ -122,7 +122,7 @@ describe('Neutron / Simple', () => {
       test('check uatom token balance transfered  via IBC on Neutron', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm.queryBalances(
-          testState.wallets.qaOne.demo1.address.toString(),
+          testState.wallets.qaOne.genQaWal1.address.toString(),
         );
         expect(
           balances.balances.find(
@@ -159,7 +159,7 @@ describe('Neutron / Simple', () => {
           JSON.stringify({
             send: {
               channel: 'channel-0',
-              to: testState.wallets.qaTwo.demo2.address.toString(),
+              to: testState.wallets.qaTwo.genQaWal1.address.toString(),
               denom: NEUTRON_DENOM,
               amount: '1000',
             },
@@ -171,7 +171,7 @@ describe('Neutron / Simple', () => {
       test('check wallet balance', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm2.queryBalances(
-          testState.wallets.qaTwo.demo2.address.toString(),
+          testState.wallets.qaTwo.genQaWal1.address.toString(),
         );
         // we expect X4 balance because the contract sends 2 txs: first one = amount and the second one amount*2 + transfer from a usual account
         expect(
@@ -223,7 +223,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.qaTwo.demo2.address.toString(),
+                to: testState.wallets.qaTwo.genQaWal1.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -280,7 +280,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.qaTwo.demo2.address.toString(),
+                to: testState.wallets.qaTwo.genQaWal1.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -310,7 +310,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.qaTwo.demo2.address.toString(),
+                to: testState.wallets.qaTwo.genQaWal1.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -351,7 +351,7 @@ describe('Neutron / Simple', () => {
           JSON.stringify({
             send: {
               channel: 'channel-0',
-              to: testState.wallets.qaTwo.demo2.address.toString(),
+              to: testState.wallets.qaTwo.genQaWal1.address.toString(),
               denom: NEUTRON_DENOM,
               amount: '1000',
             },
@@ -375,7 +375,7 @@ describe('Neutron / Simple', () => {
               JSON.stringify({
                 send: {
                   channel: 'channel-0',
-                  to: testState.wallets.qaTwo.demo2.address.toString(),
+                  to: testState.wallets.qaTwo.genQaWal1.address.toString(),
                   denom: NEUTRON_DENOM,
                   amount: '1000',
                   timeout_height: currentHeight + 2,

--- a/src/testcases/simple.test.ts
+++ b/src/testcases/simple.test.ts
@@ -24,13 +24,13 @@ describe('Neutron / Simple', () => {
     cm = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.qaOne.genQaWal1,
+      testState.wallets.qaNeutron.genQaWal1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.qaTwo.genQaWal1,
+      testState.wallets.qaCosmos.genQaWal1,
       COSMOS_DENOM,
     );
   });
@@ -85,7 +85,7 @@ describe('Neutron / Simple', () => {
           'transfer',
           'channel-0',
           { denom: NEUTRON_DENOM, amount: '1000' },
-          testState.wallets.qaTwo.genQaWal1.address.toString(),
+          testState.wallets.qaCosmos.genQaWal1.address.toString(),
           {
             revision_number: new Long(2),
             revision_height: new Long(100000000),
@@ -96,7 +96,7 @@ describe('Neutron / Simple', () => {
       test('check IBC token balance', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm2.queryBalances(
-          testState.wallets.qaTwo.genQaWal1.address.toString(),
+          testState.wallets.qaCosmos.genQaWal1.address.toString(),
         );
         expect(
           balances.balances.find(
@@ -111,7 +111,7 @@ describe('Neutron / Simple', () => {
           'transfer',
           'channel-0',
           { denom: COSMOS_DENOM, amount: '1000' },
-          testState.wallets.qaOne.genQaWal1.address.toString(),
+          testState.wallets.qaNeutron.genQaWal1.address.toString(),
           {
             revision_number: new Long(2),
             revision_height: new Long(100000000),
@@ -122,7 +122,7 @@ describe('Neutron / Simple', () => {
       test('check uatom token balance transfered  via IBC on Neutron', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm.queryBalances(
-          testState.wallets.qaOne.genQaWal1.address.toString(),
+          testState.wallets.qaNeutron.genQaWal1.address.toString(),
         );
         expect(
           balances.balances.find(
@@ -159,7 +159,7 @@ describe('Neutron / Simple', () => {
           JSON.stringify({
             send: {
               channel: 'channel-0',
-              to: testState.wallets.qaTwo.genQaWal1.address.toString(),
+              to: testState.wallets.qaCosmos.genQaWal1.address.toString(),
               denom: NEUTRON_DENOM,
               amount: '1000',
             },
@@ -171,7 +171,7 @@ describe('Neutron / Simple', () => {
       test('check wallet balance', async () => {
         await cm.blockWaiter.waitBlocks(10);
         const balances = await cm2.queryBalances(
-          testState.wallets.qaTwo.genQaWal1.address.toString(),
+          testState.wallets.qaCosmos.genQaWal1.address.toString(),
         );
         // we expect X4 balance because the contract sends 2 txs: first one = amount and the second one amount*2 + transfer from a usual account
         expect(
@@ -223,7 +223,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.qaTwo.genQaWal1.address.toString(),
+                to: testState.wallets.qaCosmos.genQaWal1.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -280,7 +280,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.qaTwo.genQaWal1.address.toString(),
+                to: testState.wallets.qaCosmos.genQaWal1.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -310,7 +310,7 @@ describe('Neutron / Simple', () => {
             JSON.stringify({
               send: {
                 channel: 'channel-0',
-                to: testState.wallets.qaTwo.genQaWal1.address.toString(),
+                to: testState.wallets.qaCosmos.genQaWal1.address.toString(),
                 denom: NEUTRON_DENOM,
                 amount: '1000',
               },
@@ -351,7 +351,7 @@ describe('Neutron / Simple', () => {
           JSON.stringify({
             send: {
               channel: 'channel-0',
-              to: testState.wallets.qaTwo.genQaWal1.address.toString(),
+              to: testState.wallets.qaCosmos.genQaWal1.address.toString(),
               denom: NEUTRON_DENOM,
               amount: '1000',
             },
@@ -375,7 +375,7 @@ describe('Neutron / Simple', () => {
               JSON.stringify({
                 send: {
                   channel: 'channel-0',
-                  to: testState.wallets.qaTwo.genQaWal1.address.toString(),
+                  to: testState.wallets.qaCosmos.genQaWal1.address.toString(),
                   denom: NEUTRON_DENOM,
                   amount: '1000',
                   timeout_height: currentHeight + 2,

--- a/src/testcases/tokenomics.test.ts
+++ b/src/testcases/tokenomics.test.ts
@@ -21,13 +21,13 @@ describe('Neutron / Tokenomics', () => {
     cmNeutron = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.neutron.demo1,
+      testState.wallets.qaOne.demo1,
       NEUTRON_DENOM,
     );
     cmGaia = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.cosmos.demo2,
+      testState.wallets.qaTwo.demo2,
       COSMOS_DENOM,
     );
   });
@@ -153,7 +153,7 @@ describe('Neutron / Tokenomics', () => {
         cmNeutron.blockWaiter,
         async () =>
           cmNeutron.queryBalances(
-            testState.wallets.neutron.demo1.address.toString(),
+            testState.wallets.qaOne.demo1.address.toString(),
           ),
         async (balances) =>
           balances.balances.find(

--- a/src/testcases/tokenomics.test.ts
+++ b/src/testcases/tokenomics.test.ts
@@ -146,7 +146,7 @@ describe('Neutron / Tokenomics', () => {
           denom: COSMOS_DENOM,
           amount: '100000',
         },
-        testState.wallets.neutron.demo1.address.toString(),
+        testState.wallets.qaOne.demo1.address.toString(),
         { revision_number: new Long(2), revision_height: new Long(100000000) },
       );
       await getWithAttempts(

--- a/src/testcases/tokenomics.test.ts
+++ b/src/testcases/tokenomics.test.ts
@@ -21,13 +21,13 @@ describe('Neutron / Tokenomics', () => {
     cmNeutron = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.qaOne.demo1,
+      testState.wallets.qaOne.genQaWal1,
       NEUTRON_DENOM,
     );
     cmGaia = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.qaTwo.demo2,
+      testState.wallets.qaTwo.genQaWal1,
       COSMOS_DENOM,
     );
   });
@@ -146,14 +146,14 @@ describe('Neutron / Tokenomics', () => {
           denom: COSMOS_DENOM,
           amount: '100000',
         },
-        testState.wallets.qaOne.demo1.address.toString(),
+        testState.wallets.qaOne.genQaWal1.address.toString(),
         { revision_number: new Long(2), revision_height: new Long(100000000) },
       );
       await getWithAttempts(
         cmNeutron.blockWaiter,
         async () =>
           cmNeutron.queryBalances(
-            testState.wallets.qaOne.demo1.address.toString(),
+            testState.wallets.qaOne.genQaWal1.address.toString(),
           ),
         async (balances) =>
           balances.balances.find(

--- a/src/testcases/tokenomics.test.ts
+++ b/src/testcases/tokenomics.test.ts
@@ -21,13 +21,13 @@ describe('Neutron / Tokenomics', () => {
     cmNeutron = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.neutron.demo1,
+      testState.wallets.qaOne.demo1,
       NEUTRON_DENOM,
     );
     cmGaia = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.cosmos.demo2,
+      testState.wallets.qaTwo.demo2,
       COSMOS_DENOM,
     );
   });
@@ -146,14 +146,14 @@ describe('Neutron / Tokenomics', () => {
           denom: COSMOS_DENOM,
           amount: '100000',
         },
-        testState.wallets.neutron.demo1.address.toString(),
+        testState.wallets.qaOne.demo1.address.toString(),
         { revision_number: new Long(2), revision_height: new Long(100000000) },
       );
       await getWithAttempts(
         cmNeutron.blockWaiter,
         async () =>
           cmNeutron.queryBalances(
-            testState.wallets.neutron.demo1.address.toString(),
+            testState.wallets.qaOne.demo1.address.toString(),
           ),
         async (balances) =>
           balances.balances.find(

--- a/src/testcases/tokenomics.test.ts
+++ b/src/testcases/tokenomics.test.ts
@@ -21,13 +21,13 @@ describe('Neutron / Tokenomics', () => {
     cmNeutron = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.qaOne.genQaWal1,
+      testState.wallets.qaNeutron.genQaWal1,
       NEUTRON_DENOM,
     );
     cmGaia = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.qaTwo.genQaWal1,
+      testState.wallets.qaCosmos.genQaWal1,
       COSMOS_DENOM,
     );
   });
@@ -146,14 +146,14 @@ describe('Neutron / Tokenomics', () => {
           denom: COSMOS_DENOM,
           amount: '100000',
         },
-        testState.wallets.qaOne.genQaWal1.address.toString(),
+        testState.wallets.qaNeutron.genQaWal1.address.toString(),
         { revision_number: new Long(2), revision_height: new Long(100000000) },
       );
       await getWithAttempts(
         cmNeutron.blockWaiter,
         async () =>
           cmNeutron.queryBalances(
-            testState.wallets.qaOne.genQaWal1.address.toString(),
+            testState.wallets.qaNeutron.genQaWal1.address.toString(),
           ),
         async (balances) =>
           balances.balances.find(

--- a/src/testcases/tokenomics.test.ts
+++ b/src/testcases/tokenomics.test.ts
@@ -21,13 +21,13 @@ describe('Neutron / Tokenomics', () => {
     cmNeutron = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.qaOne.demo1,
+      testState.wallets.neutron.demo1,
       NEUTRON_DENOM,
     );
     cmGaia = new CosmosWrapper(
       testState.sdk2,
       testState.blockWaiter2,
-      testState.wallets.qaTwo.demo2,
+      testState.wallets.cosmos.demo2,
       COSMOS_DENOM,
     );
   });
@@ -146,14 +146,14 @@ describe('Neutron / Tokenomics', () => {
           denom: COSMOS_DENOM,
           amount: '100000',
         },
-        testState.wallets.qaOne.demo1.address.toString(),
+        testState.wallets.neutron.demo1.address.toString(),
         { revision_number: new Long(2), revision_height: new Long(100000000) },
       );
       await getWithAttempts(
         cmNeutron.blockWaiter,
         async () =>
           cmNeutron.queryBalances(
-            testState.wallets.qaOne.demo1.address.toString(),
+            testState.wallets.neutron.demo1.address.toString(),
           ),
         async (balances) =>
           balances.balances.find(

--- a/src/testcases/treasury.test.ts
+++ b/src/testcases/treasury.test.ts
@@ -33,19 +33,19 @@ describe('Neutron / Treasury', () => {
     cm = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.neutron.demo1,
+      testState.wallets.qaNeutron.genQaWal1,
       NEUTRON_DENOM,
     );
     cm2 = new CosmosWrapper(
       testState.sdk1,
       testState.blockWaiter1,
-      testState.wallets.neutron.demo2,
+      testState.wallets.qaNeutronThree.genQaWal1,
       NEUTRON_DENOM,
     );
-    main_dao_wallet = testState.wallets.neutron.demo1;
-    security_dao_wallet = testState.wallets.neutron.icq;
-    holder_1_wallet = testState.wallets.neutron.demo2;
-    holder_2_wallet = testState.wallets.neutron.rly1;
+    main_dao_wallet = testState.wallets.qaNeutron.genQaWal1;
+    security_dao_wallet = testState.wallets.qaNeutronFour.genQaWal1;
+    holder_1_wallet = testState.wallets.qaNeutronThree.genQaWal1;
+    holder_2_wallet = testState.wallets.qaNeutronFive.genQaWal1;
     main_dao_addr = main_dao_wallet.address;
     security_dao_addr = security_dao_wallet.address;
     holder_1_addr = holder_1_wallet.address;


### PR DESCRIPTION
Task [NTRN-312](https://p2pvalidator.atlassian.net/jira/software/projects/NTRN/boards/121?selectedIssue=NTRN-312)

Tests work when run with the `NO_DOCKER=1 `flag

A new command has been added to package.json to run two test suites in parallel:
`test:parallel `

These two test suites (`tokenomics` and `simple`) use the generated wallets, and run in parallel. 
You can also run `treausury` together with it - it still uses the old wallets, but it can run in parallel with `tokenomics` and `simple`.

[NTRN-312]: https://p2pvalidator.atlassian.net/browse/NTRN-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ