### PR TITLE
Update hermes to latest version

### DIFF
--- a/setup/Makefile
+++ b/setup/Makefile
@@ -8,7 +8,7 @@ build-neutron:
 		@docker buildx build --load --build-context app=$(APP_DIR)/neutron -t neutron-node -f dockerbuilds/Dockerfile.neutron --build-arg BINARY=neutrond .
 
 build-hermes:
-		@docker build -f dockerbuilds/Dockerfile.hermes -t hermes:a285c01 .
+		@docker build -f dockerbuilds/Dockerfile.hermes -t hermes:1.3.0-a285c01 .
 
 build-relayer:
 		cd $(APP_DIR)/neutron-query-relayer/ && make build-docker

--- a/setup/Makefile
+++ b/setup/Makefile
@@ -8,7 +8,7 @@ build-neutron:
 		@docker buildx build --load --build-context app=$(APP_DIR)/neutron -t neutron-node -f dockerbuilds/Dockerfile.neutron --build-arg BINARY=neutrond .
 
 build-hermes:
-		@docker build -f dockerbuilds/Dockerfile.hermes -t hermes:1.0.0 .
+		@docker build -f dockerbuilds/Dockerfile.hermes -t hermes:master .
 
 build-relayer:
 		cd $(APP_DIR)/neutron-query-relayer/ && make build-docker

--- a/setup/Makefile
+++ b/setup/Makefile
@@ -8,7 +8,7 @@ build-neutron:
 		@docker buildx build --load --build-context app=$(APP_DIR)/neutron -t neutron-node -f dockerbuilds/Dockerfile.neutron --build-arg BINARY=neutrond .
 
 build-hermes:
-		@docker build -f dockerbuilds/Dockerfile.hermes -t hermes:master .
+		@docker build -f dockerbuilds/Dockerfile.hermes -t hermes:a577b27 .
 
 build-relayer:
 		cd $(APP_DIR)/neutron-query-relayer/ && make build-docker

--- a/setup/Makefile
+++ b/setup/Makefile
@@ -8,7 +8,7 @@ build-neutron:
 		@docker buildx build --load --build-context app=$(APP_DIR)/neutron -t neutron-node -f dockerbuilds/Dockerfile.neutron --build-arg BINARY=neutrond .
 
 build-hermes:
-		@docker build -f dockerbuilds/Dockerfile.hermes -t hermes:a577b27 .
+		@docker build -f dockerbuilds/Dockerfile.hermes -t hermes:a285c01 .
 
 build-relayer:
 		cd $(APP_DIR)/neutron-query-relayer/ && make build-docker

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - RUN_BACKGROUND=0
 
   hermes:
-    image: hermes:a285c01
+    image: hermes:1.3.0-a285c01
     depends_on:
       - "neutron-node"
       - "gaia-node"

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - RUN_BACKGROUND=0
 
   hermes:
-    image: hermes:a577b27
+    image: hermes:a285c01
     depends_on:
       - "neutron-node"
       - "gaia-node"

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - RUN_BACKGROUND=0
 
   hermes:
-    image: hermes:1.0.0
+    image: hermes:master
     depends_on:
       - "neutron-node"
       - "gaia-node"

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - RUN_BACKGROUND=0
 
   hermes:
-    image: hermes:master
+    image: hermes:a577b27
     depends_on:
       - "neutron-node"
       - "gaia-node"

--- a/setup/dockerbuilds/Dockerfile.hermes
+++ b/setup/dockerbuilds/Dockerfile.hermes
@@ -1,10 +1,10 @@
-FROM rust:1.63-bullseye as builder
+FROM rust:1.65-bullseye as builder
 ADD ./hermes/ /app/network/hermes/
 WORKDIR /app
 RUN PLATFORM=`uname -a | awk '{print $(NF-1)}'` && \
-    git clone https://github.com/neutron-org/hermes && \
+    git clone https://github.com/informalsystems/hermes && \
     cd hermes && \
-    git checkout 7defaf067dbe6f60588518ea1619f228d38ac48d && \
+    git checkout master && \
     cargo build --release --bin hermes && \
     mkdir -p $HOME/.hermes/bin && \
     mv ./target/release/hermes $HOME/.hermes/bin/

--- a/setup/dockerbuilds/Dockerfile.hermes
+++ b/setup/dockerbuilds/Dockerfile.hermes
@@ -4,7 +4,7 @@ WORKDIR /app
 RUN PLATFORM=`uname -a | awk '{print $(NF-1)}'` && \
     git clone https://github.com/informalsystems/hermes && \
     cd hermes && \
-    git checkout a577b27194740705dcde1ecf1e384a3299834183 && \
+    git checkout a285c015c604819b213c1582d901e5ef140d3f47 && \
     cargo build --release --bin hermes && \
     mkdir -p $HOME/.hermes/bin && \
     mv ./target/release/hermes $HOME/.hermes/bin/

--- a/setup/dockerbuilds/Dockerfile.hermes
+++ b/setup/dockerbuilds/Dockerfile.hermes
@@ -4,7 +4,7 @@ WORKDIR /app
 RUN PLATFORM=`uname -a | awk '{print $(NF-1)}'` && \
     git clone https://github.com/informalsystems/hermes && \
     cd hermes && \
-    git checkout master && \
+    git checkout a577b27194740705dcde1ecf1e384a3299834183 && \
     cargo build --release --bin hermes && \
     mkdir -p $HOME/.hermes/bin && \
     mv ./target/release/hermes $HOME/.hermes/bin/


### PR DESCRIPTION
This PR will upgrade hermes to latest version of master branch on original repo. After merging our own fork of the hermes relayer repo (https://github.com/neutron-org/hermes) will not be required.

[Test run](https://github.com/neutron-org/neutron-tests/actions/runs/4477253723)