### PR TITLE
download hermes binary instead of building it

### DIFF
--- a/setup/dockerbuilds/Dockerfile.hermes
+++ b/setup/dockerbuilds/Dockerfile.hermes
@@ -2,12 +2,12 @@ FROM rust:1.65-bullseye as builder
 ADD ./hermes/ /app/network/hermes/
 WORKDIR /app
 RUN PLATFORM=`uname -a | awk '{print $(NF-1)}'` && \
-    git clone https://github.com/informalsystems/hermes && \
-    cd hermes && \
-    git checkout v1.4.0 && \
-    cargo build --release --bin hermes && \
+    VERSION=v1.4.0 && \
+    TARNAME="hermes-${VERSION}-${PLATFORM}-unknown-linux-gnu.tar.gz" && \
+    wget "https://github.com/informalsystems/hermes/releases/download/${VERSION}/${TARNAME}" && \
+    tar -xf "$TARNAME" && \
     mkdir -p $HOME/.hermes/bin && \
-    mv ./target/release/hermes $HOME/.hermes/bin/
+    mv ./hermes $HOME/.hermes/bin/
 
 FROM debian:bullseye-slim
 COPY --from=builder /root/.hermes/bin/hermes /usr/local/bin/

--- a/setup/dockerbuilds/Dockerfile.hermes
+++ b/setup/dockerbuilds/Dockerfile.hermes
@@ -1,18 +1,14 @@
-FROM rust:1.65-bullseye as builder
-ADD ./hermes/ /app/network/hermes/
+FROM ubuntu:23.04
+COPY ./hermes/ /app/network/hermes/
 WORKDIR /app
-RUN PLATFORM=`uname -a | awk '{print $(NF-1)}'` && \
+RUN apt-get update && apt-get install -y wget && \
+    PLATFORM=`uname -a | awk '{print $(NF-1)}'` && \
     VERSION=v1.4.0 && \
     TARNAME="hermes-${VERSION}-${PLATFORM}-unknown-linux-gnu.tar.gz" && \
     wget "https://github.com/informalsystems/hermes/releases/download/${VERSION}/${TARNAME}" && \
     tar -xf "$TARNAME" && \
-    mkdir -p $HOME/.hermes/bin && \
-    mv ./hermes $HOME/.hermes/bin/
-
-FROM debian:bullseye-slim
-COPY --from=builder /root/.hermes/bin/hermes /usr/local/bin/
-COPY ./hermes/ /app/network/hermes/
-WORKDIR /app
+    mv ./hermes /usr/local/bin/ && \
+    rm -rf "$TARNAME"
 
 CMD /app/network/hermes/restore-keys.sh && \
     /app/network/hermes/create-conn.sh && \


### PR DESCRIPTION
Currently to run the integration tests locally one has to build the hermes image which implies building the hermes from sources. It takes significant time (like, dozens of minutes) while hermes version doesn't change much and it's not necessary to build it from scratch since it's the test environment.
This PR is to replace the building process with binary download. The caveat is if we will need a specific commit we'd need to roll back it to building once again.