### PR TITLE
[NTRN-483] feat: proper vesting for generator

### DIFF
--- a/src/helpers/tge.ts
+++ b/src/helpers/tge.ts
@@ -22,7 +22,7 @@ import { msgMintDenom, msgCreateDenom } from './tokenfactory';
 // subdenom of rewards asset distributed by the generator contract.
 const ASTRO_SUBDENOM = 'uastro';
 // total size of rewards allocated for generator contract.
-const TOTAL_GENERATOR_REWARDS = 1000000;
+const GENERATOR_REWARDS_TOTAL = 1000000;
 // fraction of generator rewards allocated with each new block.
 const GENERATOR_REWARDS_PER_BLOCK = 500;
 
@@ -111,6 +111,7 @@ export class Tge {
   usdcDenom: string;
   neutronDenom: string;
   astroDenom: string;
+  generatorRewardsTotal: number;
   generatorRewardsPerBlock: number;
   pairs: {
     atom_ntrn: { contract: string; liquidity: string };
@@ -164,6 +165,7 @@ export class Tge {
     this.atomDenom = atomDenom;
     this.usdcDenom = usdcDenom;
     this.neutronDenom = neutronDenom;
+    this.generatorRewardsTotal = GENERATOR_REWARDS_TOTAL;
     this.generatorRewardsPerBlock = GENERATOR_REWARDS_PER_BLOCK;
     this.times = {};
     this.times.airdropStart = 0;
@@ -300,13 +302,18 @@ export class Tge {
           vesting_accounts: [
             vestingAccount(this.contracts.astroGenerator, [
               vestingSchedule(
-                vestingSchedulePoint(0, TOTAL_GENERATOR_REWARDS.toString()),
+                vestingSchedulePoint(0, this.generatorRewardsTotal.toString()),
               ),
             ]),
           ],
         },
       }),
-      [{ denom: this.astroDenom, amount: TOTAL_GENERATOR_REWARDS.toString() }],
+      [
+        {
+          denom: this.astroDenom,
+          amount: this.generatorRewardsTotal.toString(),
+        },
+      ],
     );
 
     await this.instantiator.executeContract(
@@ -558,7 +565,7 @@ export class Tge {
       this.instantiator.wallet.address.toString(),
       {
         denom: this.astroDenom,
-        amount: TOTAL_GENERATOR_REWARDS.toString(),
+        amount: this.generatorRewardsTotal.toString(),
       },
     );
   }

--- a/src/helpers/tge.ts
+++ b/src/helpers/tge.ts
@@ -9,7 +9,7 @@ import {
   nativeTokenInfo,
   vestingAccount,
   vestingSchedule,
-  vestingSchedulePount,
+  vestingSchedulePoint,
 } from './types';
 import {
   CreditsVaultConfig,
@@ -300,7 +300,7 @@ export class Tge {
           vesting_accounts: [
             vestingAccount(this.contracts.astroGenerator, [
               vestingSchedule(
-                vestingSchedulePount(0, TOTAL_GENERATOR_REWARDS.toString()),
+                vestingSchedulePoint(0, TOTAL_GENERATOR_REWARDS.toString()),
               ),
             ]),
           ],

--- a/src/helpers/tge.ts
+++ b/src/helpers/tge.ts
@@ -19,8 +19,8 @@ import {
 import { InlineResponse20075TxResponse } from '@cosmos-client/core/cjs/openapi/api';
 import { msgMintDenom, msgCreateDenom } from './tokenfactory';
 
-// denom of rewards distributed by the generator contract.
-const ASTRO_DENOM = 'uibcastro';
+// subdenom of rewards asset distributed by the generator contract.
+const ASTRO_SUBDENOM = 'uastro';
 // total size of rewards allocated for generator contract.
 const TOTAL_GENERATOR_REWARDS = 1000000;
 // fraction of generator rewards allocated with each new block.
@@ -546,7 +546,7 @@ export class Tge {
     const data = await msgCreateDenom(
       this.instantiator,
       this.instantiator.wallet.address.toString(),
-      ASTRO_DENOM,
+      ASTRO_SUBDENOM,
     );
     this.astroDenom = getEventAttribute(
       (data as any).events,

--- a/src/helpers/tge.ts
+++ b/src/helpers/tge.ts
@@ -564,7 +564,7 @@ export class Tge {
   }
 
   /**
-   * retrieves user's ntrn and astro balances, lockdrop info and generator's vesting account
+   * retrieves user's ntrn and astro balances, lockdrop info and user's LP token balances.
    */
   async generatorRewardsState(user: string): Promise<GeneratorRewardsState> {
     const balanceNtrn = await this.chain.queryDenomBalance(
@@ -853,18 +853,6 @@ export type LockdropUserInfoResponse = {
   lockup_positions_index: number;
   ntrn_transferred: boolean;
   total_ntrn_rewards: string;
-};
-
-export type LockdropUserInfoWithListResponse = {
-  total_ntrn_rewards: string;
-  ntrn_transferred: boolean;
-  lockup_infos: LockdropLockUpInfoSummary[];
-  lockup_positions_index: number;
-};
-
-export type LockdropLockUpInfoSummary = {
-  pool_type: string;
-  duration: number;
 };
 
 export const instantiateLockdrop = async (

--- a/src/helpers/tokenfactory.ts
+++ b/src/helpers/tokenfactory.ts
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { cosmosclient } from '@cosmos-client/core';
+import { cosmos, osmosis } from '../generated/proto';
+import ICoin = cosmos.base.v1beta1.ICoin;
+import { InlineResponse20075TxResponse } from '@cosmos-client/core/cjs/openapi/api';
+import { WalletWrapper } from '../helpers/cosmos';
+import Long from 'long';
+
+cosmosclient.codec.register(
+  '/osmosis.tokenfactory.v1beta1.MsgCreateDenom',
+  osmosis.tokenfactory.v1beta1.MsgCreateDenom,
+);
+cosmosclient.codec.register(
+  '/osmosis.tokenfactory.v1beta1.MsgMint',
+  osmosis.tokenfactory.v1beta1.MsgMint,
+);
+cosmosclient.codec.register(
+  '/osmosis.tokenfactory.v1beta1.MsgBurn',
+  osmosis.tokenfactory.v1beta1.MsgBurn,
+);
+cosmosclient.codec.register(
+  '/osmosis.tokenfactory.v1beta1.MsgChangeAdmin',
+  osmosis.tokenfactory.v1beta1.MsgChangeAdmin,
+);
+
+export const msgMintDenom = async (
+  cmNeutron: WalletWrapper,
+  creator: string,
+  amount: ICoin,
+): Promise<InlineResponse20075TxResponse> => {
+  const msgCreateDenom = new osmosis.tokenfactory.v1beta1.MsgMint({
+    sender: creator,
+    amount,
+  });
+  const res = await cmNeutron.execTx(
+    {
+      gas_limit: Long.fromString('200000'),
+      amount: [{ denom: cmNeutron.chain.denom, amount: '1000' }],
+    },
+    [msgCreateDenom],
+    10,
+  );
+
+  return res.tx_response!;
+};
+
+export const msgCreateDenom = async (
+  cmNeutron: WalletWrapper,
+  creator: string,
+  subdenom: string,
+): Promise<InlineResponse20075TxResponse> => {
+  const msgCreateDenom = new osmosis.tokenfactory.v1beta1.MsgCreateDenom({
+    sender: creator,
+    subdenom,
+  });
+  const res = await cmNeutron.execTx(
+    {
+      gas_limit: Long.fromString('200000'),
+      amount: [{ denom: cmNeutron.chain.denom, amount: '1000' }],
+    },
+    [msgCreateDenom],
+    10,
+  );
+
+  return res.tx_response!;
+};
+
+export const msgBurn = async (
+  cmNeutron: WalletWrapper,
+  creator: string,
+  denom: string,
+  amountToBurn: string,
+): Promise<InlineResponse20075TxResponse> => {
+  const msgBurn = new osmosis.tokenfactory.v1beta1.MsgBurn({
+    sender: creator,
+    amount: {
+      denom: denom,
+      amount: amountToBurn,
+    },
+  });
+  const res = await cmNeutron.execTx(
+    {
+      gas_limit: Long.fromString('200000'),
+      amount: [{ denom: cmNeutron.chain.denom, amount: '1000' }],
+    },
+    [msgBurn],
+    10,
+  );
+
+  return res.tx_response!;
+};
+
+// Create MsgChangeAdmin message
+export const msgChangeAdmin = async (
+  cmNeutron: WalletWrapper,
+  creator: string,
+  denom: string,
+  newAdmin: string,
+): Promise<InlineResponse20075TxResponse> => {
+  const msgChangeAdmin = new osmosis.tokenfactory.v1beta1.MsgChangeAdmin({
+    sender: creator,
+    denom,
+    newAdmin,
+  });
+  const res = await cmNeutron.execTx(
+    {
+      gas_limit: Long.fromString('200000'),
+      amount: [{ denom: cmNeutron.chain.denom, amount: '1000' }],
+    },
+    [msgChangeAdmin],
+    10,
+  );
+
+  return res.tx_response!;
+};

--- a/src/helpers/tokenfactory.ts
+++ b/src/helpers/tokenfactory.ts
@@ -28,7 +28,7 @@ export const msgMintDenom = async (
   creator: string,
   amount: ICoin,
 ): Promise<InlineResponse20075TxResponse> => {
-  const msgCreateDenom = new osmosis.tokenfactory.v1beta1.MsgMint({
+  const msgMint = new osmosis.tokenfactory.v1beta1.MsgMint({
     sender: creator,
     amount,
   });
@@ -37,7 +37,7 @@ export const msgMintDenom = async (
       gas_limit: Long.fromString('200000'),
       amount: [{ denom: cmNeutron.chain.denom, amount: '1000' }],
     },
-    [msgCreateDenom],
+    [msgMint],
     10,
   );
 

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -206,7 +206,7 @@ export const vestingSchedule = (
   end_point: endPoint,
 });
 
-export const vestingSchedulePount = (
+export const vestingSchedulePoint = (
   time: number,
   amount: string,
 ): VestingSchedulePoint => ({

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -142,6 +142,7 @@ export const NeutronContract = {
   ASTRO_TOKEN: '../contracts_thirdparty/astroport_token.wasm',
   ASTRO_GENERATOR: '../contracts_thirdparty/astroport_generator.wasm',
   ASTRO_WHITELIST: '../contracts_thirdparty/astroport_whitelist.wasm',
+  ASTRO_VESTING: '../contracts_thirdparty/astroport_vesting.wasm',
   VESTING_LP: 'vesting_lp.wasm',
   VESTING_LP_VAULT: 'vesting_lp_vault.wasm',
   CREDITS_VAULT: 'credits_vault.wasm',

--- a/src/testcases/parallel/tge.investors_vesting_vault.test.ts
+++ b/src/testcases/parallel/tge.investors_vesting_vault.test.ts
@@ -8,7 +8,7 @@ import {
   NeutronContract,
   vestingAccount,
   vestingSchedule,
-  vestingSchedulePount,
+  vestingSchedulePoint,
 } from '../../helpers/types';
 import { getHeight } from '../../helpers/wait';
 import { TestStateLocalCosmosTestNet } from '../common_localcosmosnet';
@@ -116,12 +116,12 @@ describe('Neutron / TGE / Investors vesting vault', () => {
               vesting_accounts: [
                 vestingAccount(cmUser1.wallet.address.toString(), [
                   vestingSchedule(
-                    vestingSchedulePount(0, user1VestingAmount.toString()),
+                    vestingSchedulePoint(0, user1VestingAmount.toString()),
                   ),
                 ]),
                 vestingAccount(cmUser2.wallet.address.toString(), [
                   vestingSchedule(
-                    vestingSchedulePount(0, user2VestingAmount.toString()),
+                    vestingSchedulePoint(0, user2VestingAmount.toString()),
                   ),
                 ]),
               ],
@@ -345,7 +345,7 @@ describe('Neutron / TGE / Investors vesting vault', () => {
               vesting_accounts: [
                 vestingAccount(cmUser1.wallet.address.toString(), [
                   vestingSchedule(
-                    vestingSchedulePount(0, vestingAmount.toString()),
+                    vestingSchedulePoint(0, vestingAmount.toString()),
                   ),
                 ]),
               ],
@@ -544,7 +544,7 @@ describe('Neutron / TGE / Investors vesting vault', () => {
                       register_vesting_accounts: {
                         vesting_accounts: [
                           vestingAccount(cmUser1.wallet.address.toString(), [
-                            vestingSchedule(vestingSchedulePount(0, '1000')),
+                            vestingSchedule(vestingSchedulePoint(0, '1000')),
                           ]),
                         ],
                       },
@@ -563,7 +563,7 @@ describe('Neutron / TGE / Investors vesting vault', () => {
                 register_vesting_accounts: {
                   vesting_accounts: [
                     vestingAccount(cmUser2.wallet.address.toString(), [
-                      vestingSchedule(vestingSchedulePount(0, '1000')),
+                      vestingSchedule(vestingSchedulePoint(0, '1000')),
                     ]),
                   ],
                 },

--- a/src/testcases/parallel/tge.vesting_lp_vault.test.ts
+++ b/src/testcases/parallel/tge.vesting_lp_vault.test.ts
@@ -12,7 +12,7 @@ import {
   nativeTokenInfo,
   vestingAccount,
   vestingSchedule,
-  vestingSchedulePount,
+  vestingSchedulePoint,
   NativeToken,
   Token,
 } from '../../helpers/types';
@@ -344,7 +344,7 @@ describe('Neutron / TGE / Vesting LP vault', () => {
                     vesting_accounts: [
                       vestingAccount(cmUser1.wallet.address.toString(), [
                         vestingSchedule(
-                          vestingSchedulePount(
+                          vestingSchedulePoint(
                             0,
                             user1AtomVestingAmount.toString(),
                           ),
@@ -352,7 +352,7 @@ describe('Neutron / TGE / Vesting LP vault', () => {
                       ]),
                       vestingAccount(cmUser2.wallet.address.toString(), [
                         vestingSchedule(
-                          vestingSchedulePount(
+                          vestingSchedulePoint(
                             0,
                             user2AtomVestingAmount.toString(),
                           ),
@@ -380,7 +380,7 @@ describe('Neutron / TGE / Vesting LP vault', () => {
                     vesting_accounts: [
                       vestingAccount(cmUser1.wallet.address.toString(), [
                         vestingSchedule(
-                          vestingSchedulePount(
+                          vestingSchedulePoint(
                             0,
                             user1UsdcVestingAmount.toString(),
                           ),
@@ -388,7 +388,7 @@ describe('Neutron / TGE / Vesting LP vault', () => {
                       ]),
                       vestingAccount(cmUser2.wallet.address.toString(), [
                         vestingSchedule(
-                          vestingSchedulePount(
+                          vestingSchedulePoint(
                             0,
                             user2UsdcVestingAmount.toString(),
                           ),
@@ -1011,7 +1011,7 @@ describe('Neutron / TGE / Vesting LP vault', () => {
                       register_vesting_accounts: {
                         vesting_accounts: [
                           vestingAccount(cmUser1.wallet.address.toString(), [
-                            vestingSchedule(vestingSchedulePount(0, '1000')),
+                            vestingSchedule(vestingSchedulePoint(0, '1000')),
                           ]),
                         ],
                       },
@@ -1030,7 +1030,7 @@ describe('Neutron / TGE / Vesting LP vault', () => {
                 register_vesting_accounts: {
                   vesting_accounts: [
                     vestingAccount(cmUser2.wallet.address.toString(), [
-                      vestingSchedule(vestingSchedulePount(0, '1000')),
+                      vestingSchedule(vestingSchedulePoint(0, '1000')),
                     ]),
                   ],
                 },

--- a/src/testcases/parallel/tokenfactory.test.ts
+++ b/src/testcases/parallel/tokenfactory.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { TestStateLocalCosmosTestNet } from '../common_localcosmosnet';
 import {
   CosmosWrapper,
@@ -8,29 +7,13 @@ import {
 } from '../../helpers/cosmos';
 import axios from 'axios';
 import { Wallet } from '../../types';
-import { cosmosclient } from '@cosmos-client/core';
-import { cosmos, osmosis } from '../../generated/proto';
-import Long from 'long';
-import { InlineResponse20075TxResponse } from '@cosmos-client/core/cjs/openapi/api';
 import { NeutronContract } from '../../helpers/types';
-import ICoin = cosmos.base.v1beta1.ICoin;
-
-cosmosclient.codec.register(
-  '/osmosis.tokenfactory.v1beta1.MsgCreateDenom',
-  osmosis.tokenfactory.v1beta1.MsgCreateDenom,
-);
-cosmosclient.codec.register(
-  '/osmosis.tokenfactory.v1beta1.MsgMint',
-  osmosis.tokenfactory.v1beta1.MsgMint,
-);
-cosmosclient.codec.register(
-  '/osmosis.tokenfactory.v1beta1.MsgBurn',
-  osmosis.tokenfactory.v1beta1.MsgBurn,
-);
-cosmosclient.codec.register(
-  '/osmosis.tokenfactory.v1beta1.MsgChangeAdmin',
-  osmosis.tokenfactory.v1beta1.MsgChangeAdmin,
-);
+import {
+  msgBurn,
+  msgChangeAdmin,
+  msgCreateDenom,
+  msgMintDenom,
+} from '../../helpers/tokenfactory';
 
 interface DenomsFromCreator {
   readonly denoms: readonly string[];
@@ -374,95 +357,4 @@ const getAuthorityMetadata = async (
   );
 
   return res.data;
-};
-
-const msgMintDenom = async (
-  cmNeutron: WalletWrapper,
-  creator: string,
-  amount: ICoin,
-): Promise<InlineResponse20075TxResponse> => {
-  const msgCreateDenom = new osmosis.tokenfactory.v1beta1.MsgMint({
-    sender: creator,
-    amount,
-  });
-  const res = await cmNeutron.execTx(
-    {
-      gas_limit: Long.fromString('200000'),
-      amount: [{ denom: cmNeutron.chain.denom, amount: '1000' }],
-    },
-    [msgCreateDenom],
-    10,
-  );
-
-  return res.tx_response!;
-};
-
-const msgCreateDenom = async (
-  cmNeutron: WalletWrapper,
-  creator: string,
-  subdenom: string,
-): Promise<InlineResponse20075TxResponse> => {
-  const msgCreateDenom = new osmosis.tokenfactory.v1beta1.MsgCreateDenom({
-    sender: creator,
-    subdenom,
-  });
-  const res = await cmNeutron.execTx(
-    {
-      gas_limit: Long.fromString('200000'),
-      amount: [{ denom: cmNeutron.chain.denom, amount: '1000' }],
-    },
-    [msgCreateDenom],
-    10,
-  );
-
-  return res.tx_response!;
-};
-
-const msgBurn = async (
-  cmNeutron: WalletWrapper,
-  creator: string,
-  denom: string,
-  amountToBurn: string,
-): Promise<InlineResponse20075TxResponse> => {
-  const msgBurn = new osmosis.tokenfactory.v1beta1.MsgBurn({
-    sender: creator,
-    amount: {
-      denom: denom,
-      amount: amountToBurn,
-    },
-  });
-  const res = await cmNeutron.execTx(
-    {
-      gas_limit: Long.fromString('200000'),
-      amount: [{ denom: cmNeutron.chain.denom, amount: '1000' }],
-    },
-    [msgBurn],
-    10,
-  );
-
-  return res.tx_response!;
-};
-
-// Create MsgChangeAdmin message
-const msgChangeAdmin = async (
-  cmNeutron: WalletWrapper,
-  creator: string,
-  denom: string,
-  newAdmin: string,
-): Promise<InlineResponse20075TxResponse> => {
-  const msgChangeAdmin = new osmosis.tokenfactory.v1beta1.MsgChangeAdmin({
-    sender: creator,
-    denom,
-    newAdmin,
-  });
-  const res = await cmNeutron.execTx(
-    {
-      gas_limit: Long.fromString('200000'),
-      amount: [{ denom: cmNeutron.chain.denom, amount: '1000' }],
-    },
-    [msgChangeAdmin],
-    10,
-  );
-
-  return res.tx_response!;
 };

--- a/src/testcases/run_in_band/tge.auction.test.ts
+++ b/src/testcases/run_in_band/tge.auction.test.ts
@@ -1926,7 +1926,7 @@ describe('Neutron / TGE / Auction', () => {
             expectedGeneratorRewards + tge.generatorRewardsPerBlock,
           );
 
-          // withdraw_lp_stake is false => no lp tokens provided
+          // withdraw_lp_stake is false => no lp tokens returned
           expect(rewardsStateBeforeClaim.atomNtrnLpTokenBalance).toEqual(
             rewardsStateAfterClaim.atomNtrnLpTokenBalance,
           );
@@ -2019,7 +2019,7 @@ describe('Neutron / TGE / Auction', () => {
               expectedGeneratorRewards + tge.generatorRewardsPerBlock,
             );
 
-            // withdraw_lp_stake is false => no lp tokens provided
+            // withdraw_lp_stake is false => no lp tokens returned
             expect(rewardsStateBeforeClaim.atomNtrnLpTokenBalance).toEqual(
               rewardsStateAfterClaim.atomNtrnLpTokenBalance,
             );

--- a/src/testcases/run_in_band/tge.auction.test.ts
+++ b/src/testcases/run_in_band/tge.auction.test.ts
@@ -2076,6 +2076,7 @@ describe('Neutron / TGE / Auction', () => {
               +rewardsStateBeforeClaim.userInfo.lockup_infos.find(
                 (i) => i.pool_type == 'USDC' && i.duration == 1,
               )!.lp_units_locked;
+            expect(usdcNtrnLockedLp).toBeGreaterThan(0);
             expect(rewardsStateAfterClaim.usdcNtrnLpTokenBalance).toEqual(
               rewardsStateBeforeClaim.usdcNtrnLpTokenBalance + usdcNtrnLockedLp,
             );
@@ -2083,6 +2084,7 @@ describe('Neutron / TGE / Auction', () => {
               +rewardsStateBeforeClaim.userInfo.lockup_infos.find(
                 (i) => i.pool_type == 'ATOM' && i.duration == 1,
               )!.lp_units_locked;
+            expect(atomNtrnLockedLp).toBeGreaterThan(0);
             expect(rewardsStateAfterClaim.atomNtrnLpTokenBalance).toEqual(
               rewardsStateBeforeClaim.atomNtrnLpTokenBalance + atomNtrnLockedLp,
             );


### PR DESCRIPTION
**task:** https://p2pvalidator.atlassian.net/browse/NTRN-483

**this PR:**
- configures the vesting contract used by the generator with a native astro token;
- adds a vesting account for the generator making rewards available for LP (lockdrop);
- adds tests for generator rewards distribution across the lockdrop participants;
- refines lockdrop rewards tests;
- moves usable common tokenfactory funcs from the tokenfactory test file to a shared helpers file.

**related PRs:**
- https://github.com/neutron-org/neutron-tge-contracts/pull/49