### PR TITLE
feat: updated codepinids amount

### DIFF
--- a/src/testcases/parallel/governance.test.ts
+++ b/src/testcases/parallel/governance.test.ts
@@ -314,9 +314,9 @@ describe('Neutron / Governance', () => {
     });
 
     test('create proposal #15, will pass', async () => {
-      for (let i = 0; i < 100; i++)
+      for (let i = 0; i < 40; i++)
         await neutronAccount.storeWasm(NeutronContract.RESERVE);
-      const codeids = Array.from({ length: 100 }, (_, i) => i + 1);
+      const codeids = Array.from({ length: 40 }, (_, i) => i + 1);
       await daoMember1.submitPinCodesProposal(
         'Proposal #15',
         'Pin codes proposal. Will pass',


### PR DESCRIPTION
in wasmd 0.42.0 it's possible to pin upto 50 codeids in one msg, we have to reduce the amount of contracts we try to pin in the test