### PR TITLE
chore: rm contracts replacement in docker compose

### DIFF
--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -5,15 +5,12 @@ services:
     container_name: neutron-node
     volumes:
       - data:/opt/neutron/data
-      - ../contracts/:/opt/neutron/contracts
     ports:
       - 1317:1317
       - 26657:26657
       - 26656:26656
       - 8090:9090
     environment:
-      - CONTRACTS_BINARIES_DIR=/opt/neutron/contracts
-      - THIRD_PARTY_CONTRACTS_DIR=/opt/neutron/contracts_thirdparty
       - RUN_BACKGROUND=0
     networks:
       - neutron-testing


### PR DESCRIPTION
This PR removes redundant replacement of contracts used in neutron node container.

**related PRs:**
- https://github.com/neutron-org/neutron/pull/328