### PR TITLE
Feat: whitelist ibc proposal messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@cosmos-client/core": "^0.47.4",
     "@cosmos-client/cosmwasm": "^0.40.3",
     "@cosmos-client/ibc": "^1.2.1",
-    "@neutron-org/neutronjsplus": "https://github.com/neutron-org/neutronjsplus.git#44ca65a83435ea5412313b0ca3392ec1b8ecb360",
+    "@neutron-org/neutronjsplus": "https://github.com/neutron-org/neutronjsplus.git#02d0a8b9e4921523b6d4d7ca37097033fea68062",
     "@types/lodash": "^4.14.182",
     "@types/long": "^5.0.0",
     "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@cosmos-client/core": "^0.47.4",
     "@cosmos-client/cosmwasm": "^0.40.3",
     "@cosmos-client/ibc": "^1.2.1",
-    "@neutron-org/neutronjsplus": "https://github.com/neutron-org/neutronjsplus.git#068a317fa4275714e8e699f9a6a5169144d13a17",
+    "@neutron-org/neutronjsplus": "https://github.com/neutron-org/neutronjsplus.git#44ca65a83435ea5412313b0ca3392ec1b8ecb360",
     "@types/lodash": "^4.14.182",
     "@types/long": "^5.0.0",
     "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@cosmos-client/core": "^0.47.4",
     "@cosmos-client/cosmwasm": "^0.40.3",
     "@cosmos-client/ibc": "^1.2.1",
-    "@neutron-org/neutronjsplus": "https://github.com/neutron-org/neutronjsplus.git#02d0a8b9e4921523b6d4d7ca37097033fea68062",
+    "@neutron-org/neutronjsplus": "https://github.com/neutron-org/neutronjsplus.git#539032708ccc600e3c66ae9f7bbde1c8a807a8a0",
     "@types/lodash": "^4.14.182",
     "@types/long": "^5.0.0",
     "axios": "^0.27.2",

--- a/src/testcases/parallel/governance.test.ts
+++ b/src/testcases/parallel/governance.test.ts
@@ -216,13 +216,12 @@ describe('Neutron / Governance', () => {
 
     test('create proposal #6, will pass', async () => {
       const chainManagerAddress = (await neutronChain.getChainAdmins())[0];
-      await daoMember1.submitClientUpdateProposal(
+      await daoMember1.submitRecoverIBCClient(
         chainManagerAddress,
         'Proposal #6',
         'UpdateClient proposal. Will pass',
         '07-tendermint-2',
         '07-tendermint-1',
-        '1000',
       );
     });
 

--- a/src/testcases/run_in_band/slinky.test.ts
+++ b/src/testcases/run_in_band/slinky.test.ts
@@ -11,7 +11,6 @@ import {
   DaoMember,
   getDaoContracts,
 } from '@neutron-org/neutronjsplus/dist/dao';
-import ch from "child_process";
 
 const config = require('../../config.json');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1568,9 +1568,9 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.50.0.tgz#29c6419e8379d496ab6d0426eadf3c4d100cd186"
   integrity sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA==
 
-"@neutron-org/neutronjsplus@https://github.com/neutron-org/neutronjsplus.git#02d0a8b9e4921523b6d4d7ca37097033fea68062":
+"@neutron-org/neutronjsplus@https://github.com/neutron-org/neutronjsplus.git#539032708ccc600e3c66ae9f7bbde1c8a807a8a0":
   version "0.4.0-rc19"
-  resolved "https://github.com/neutron-org/neutronjsplus.git#02d0a8b9e4921523b6d4d7ca37097033fea68062"
+  resolved "https://github.com/neutron-org/neutronjsplus.git#539032708ccc600e3c66ae9f7bbde1c8a807a8a0"
   dependencies:
     "@bufbuild/protobuf" "^1.4.2"
     "@cosmos-client/core" "^0.47.4"
@@ -1825,9 +1825,9 @@
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
 "@types/lodash@^4.14.182":
-  version "4.17.1"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.1.tgz#0fabfcf2f2127ef73b119d98452bd317c4a17eb8"
-  integrity sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q==
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.4.tgz#0303b64958ee070059e3a7184048a55159fe20b7"
+  integrity sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==
 
 "@types/long@^4.0.1":
   version "4.0.2"
@@ -2423,9 +2423,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001587:
-  version "1.0.30001618"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001618.tgz#fad74fa006aef0f01e8e5c0a5540c74d8d36ec6f"
-  integrity sha512-p407+D1tIkDvsEAPS22lJxLQQaG8OTBEqo0KhzfABGk0TU4juBNDSfH0hyAp/HRyx+M8L17z/ltyhxh27FTfQg==
+  version "1.0.30001620"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz#78bb6f35b8fe315b96b8590597094145d0b146b4"
+  integrity sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==
 
 chalk@^2.3.0, chalk@^2.4.2:
   version "2.4.2"
@@ -2812,9 +2812,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.668:
-  version "1.4.767"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.767.tgz#b885cfefda5a2e7a7ee356c567602012294ed260"
-  integrity sha512-nzzHfmQqBss7CE3apQHkHjXW77+8w3ubGCIoEijKCJebPufREaFETgGXWTkh32t259F3Kcq+R8MZdFdOJROgYw==
+  version "1.4.773"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.773.tgz#49741af9bb4e712ad899e35d8344d8d59cdb7e12"
+  integrity sha512-87eHF+h3PlCRwbxVEAw9KtK3v7lWfc/sUDr0W76955AdYTG4bV/k0zrl585Qnj/skRMH2qOSiE+kqMeOQ+LOpw==
 
 elliptic@^6.4.0, elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1568,9 +1568,9 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.50.0.tgz#29c6419e8379d496ab6d0426eadf3c4d100cd186"
   integrity sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA==
 
-"@neutron-org/neutronjsplus@https://github.com/neutron-org/neutronjsplus.git#068a317fa4275714e8e699f9a6a5169144d13a17":
+"@neutron-org/neutronjsplus@https://github.com/neutron-org/neutronjsplus.git#44ca65a83435ea5412313b0ca3392ec1b8ecb360":
   version "0.4.0-rc19"
-  resolved "https://github.com/neutron-org/neutronjsplus.git#068a317fa4275714e8e699f9a6a5169144d13a17"
+  resolved "https://github.com/neutron-org/neutronjsplus.git#44ca65a83435ea5412313b0ca3392ec1b8ecb360"
   dependencies:
     "@bufbuild/protobuf" "^1.4.2"
     "@cosmos-client/core" "^0.47.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1568,9 +1568,9 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.50.0.tgz#29c6419e8379d496ab6d0426eadf3c4d100cd186"
   integrity sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA==
 
-"@neutron-org/neutronjsplus@https://github.com/neutron-org/neutronjsplus.git#44ca65a83435ea5412313b0ca3392ec1b8ecb360":
+"@neutron-org/neutronjsplus@https://github.com/neutron-org/neutronjsplus.git#02d0a8b9e4921523b6d4d7ca37097033fea68062":
   version "0.4.0-rc19"
-  resolved "https://github.com/neutron-org/neutronjsplus.git#44ca65a83435ea5412313b0ca3392ec1b8ecb360"
+  resolved "https://github.com/neutron-org/neutronjsplus.git#02d0a8b9e4921523b6d4d7ca37097033fea68062"
   dependencies:
     "@bufbuild/protobuf" "^1.4.2"
     "@cosmos-client/core" "^0.47.4"
@@ -4553,7 +4553,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-picocolors@^1.0.0:
+picocolors@^1.0.0, picocolors@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
   integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
@@ -5385,12 +5385,12 @@ unpipe@1.0.0, unpipe@~1.0.0:
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
 update-browserslist-db@^1.0.13:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.15.tgz#60ed9f8cba4a728b7ecf7356f641a31e3a691d97"
-  integrity sha512-K9HWH62x3/EalU1U6sjSZiylm9C8tgq2mSvshZpqc7QE69RaA2qjhkW2HlNA0tFpEbtyFz7HTqbSdN4MSwUodA==
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz#f6d489ed90fb2f07d67784eb3f53d7891f736356"
+  integrity sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==
   dependencies:
     escalade "^3.1.2"
-    picocolors "^1.0.0"
+    picocolors "^1.0.1"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
We need to whitelist RecoverClient and IBCSoftwareUpgrade messages since old messages (UpdateClient and UpgradeProposal respectively) is [deprecated](https://github.com/cosmos/ibc-go/releases/tag/v8.0.0) in ibc-go v8.0+.

Related PRs:
* https://github.com/neutron-org/neutron/pull/525
* https://github.com/neutron-org/neutronjsplus/pull/37