### PR TITLE
chore: bump neutronjsplus to comply with tf v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@cosmos-client/core": "^0.47.4",
     "@cosmos-client/cosmwasm": "^0.40.3",
     "@cosmos-client/ibc": "^1.2.1",
-    "@neutron-org/neutronjsplus": "https://github.com/neutron-org/neutronjsplus.git#58eb19ae11067de3bd73d0c4cd2889aca422d079",
+    "@neutron-org/neutronjsplus": "0.4.1",
     "@types/lodash": "^4.14.182",
     "@types/long": "^5.0.0",
     "axios": "^0.27.2",
@@ -86,7 +86,9 @@
       "eslint --max-warnings=0",
       "jest --bail --findRelatedTests"
     ],
-    "./**/*.{ts,tsx,js,jsx,md,json}": ["prettier --write"]
+    "./**/*.{ts,tsx,js,jsx,md,json}": [
+      "prettier --write"
+    ]
   },
   "engines": {
     "node": ">=16.0 <17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1568,9 +1568,10 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.50.0.tgz#29c6419e8379d496ab6d0426eadf3c4d100cd186"
   integrity sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA==
 
-"@neutron-org/neutronjsplus@https://github.com/neutron-org/neutronjsplus.git#58eb19ae11067de3bd73d0c4cd2889aca422d079":
-  version "0.4.0-rc19"
-  resolved "https://github.com/neutron-org/neutronjsplus.git#58eb19ae11067de3bd73d0c4cd2889aca422d079"
+"@neutron-org/neutronjsplus@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@neutron-org/neutronjsplus/-/neutronjsplus-0.4.1.tgz#5e7b6e8f0ea63873719ae9011103c297c3eca209"
+  integrity sha512-CyRAxai2Pk8tpU+0cUEGGchwwf2wBa8wfCPWJRf07PRTvBJ06sEYMfJqW0kdUtLuBc9tqEt4DD2IGfGkOrVwyg==
   dependencies:
     "@bufbuild/protobuf" "^1.4.2"
     "@cosmos-client/core" "^0.47.4"


### PR DESCRIPTION
### This PR:
- bumps neutronjsplus version to the one that has increased gas limit for tokenfactory's MsgMint

### Related PRs:
- https://github.com/neutron-org/neutron/pull/581