### PR TITLE
Feat: Whitelist tokenfactory hooks (disable tests only)

### DIFF
--- a/src/testcases/parallel/tokenfactory.test.ts
+++ b/src/testcases/parallel/tokenfactory.test.ts
@@ -12,11 +12,9 @@ import {
   msgChangeAdmin,
   msgCreateDenom,
   msgMintDenom,
-  msgSetBeforeSendHook,
   getDenomsFromCreator,
   checkTokenfactoryParams,
   getAuthorityMetadata,
-  getBeforeSendHook,
 } from '@neutron-org/neutronjsplus/dist/tokenfactory';
 
 const config = require('../../config.json');

--- a/src/testcases/parallel/tokenfactory.test.ts
+++ b/src/testcases/parallel/tokenfactory.test.ts
@@ -182,114 +182,115 @@ describe('Neutron / Tokenfactory', () => {
 
       expect(balanceAfter).toEqual(9900);
     });
-    test('create denom, set before send hook', async () => {
-      const codeId = await neutronAccount.storeWasm(
-        NeutronContract.BEFORE_SEND_HOOK_TEST,
-      );
-      expect(codeId).toBeGreaterThan(0);
+    // TEMP: remove tests for before send hook
+    // test('create denom, set before send hook', async () => {
+    //   const codeId = await neutronAccount.storeWasm(
+    //     NeutronContract.BEFORE_SEND_HOOK_TEST,
+    //   );
+    //   expect(codeId).toBeGreaterThan(0);
 
-      const res = await neutronAccount.instantiateContract(
-        codeId,
-        '{}',
-        'before_send_hook_test',
-      );
-      const contractAddress = res[0]._contract_address;
+    //   const res = await neutronAccount.instantiateContract(
+    //     codeId,
+    //     '{}',
+    //     'before_send_hook_test',
+    //   );
+    //   const contractAddress = res[0]._contract_address;
 
-      const denom = `test5`;
+    //   const denom = `test5`;
 
-      const data = await msgCreateDenom(
-        neutronAccount,
-        ownerWallet.address.toString(),
-        denom,
-      );
-      const newTokenDenom = getEventAttribute(
-        (data as any).events,
-        'create_denom',
-        'new_token_denom',
-      );
+    //   const data = await msgCreateDenom(
+    //     neutronAccount,
+    //     ownerWallet.address.toString(),
+    //     denom,
+    //   );
+    //   const newTokenDenom = getEventAttribute(
+    //     (data as any).events,
+    //     'create_denom',
+    //     'new_token_denom',
+    //   );
 
-      await msgMintDenom(neutronAccount, ownerWallet.address.toString(), {
-        denom: newTokenDenom,
-        amount: '10000',
-      });
+    //   await msgMintDenom(neutronAccount, ownerWallet.address.toString(), {
+    //     denom: newTokenDenom,
+    //     amount: '10000',
+    //   });
 
-      const balanceBefore = await neutronChain.queryDenomBalance(
-        ownerWallet.address.toString(),
-        newTokenDenom,
-      );
+    //   const balanceBefore = await neutronChain.queryDenomBalance(
+    //     ownerWallet.address.toString(),
+    //     newTokenDenom,
+    //   );
 
-      expect(balanceBefore).toEqual(10000);
+    //   expect(balanceBefore).toEqual(10000);
 
-      await neutronAccount.msgSend(contractAddress, {
-        amount: '666',
-        denom: newTokenDenom,
-      });
+    //   await neutronAccount.msgSend(contractAddress, {
+    //     amount: '666',
+    //     denom: newTokenDenom,
+    //   });
 
-      const contractBalance = await neutronChain.queryDenomBalance(
-        contractAddress,
-        newTokenDenom,
-      );
-      expect(contractBalance).toEqual(666);
+    //   const contractBalance = await neutronChain.queryDenomBalance(
+    //     contractAddress,
+    //     newTokenDenom,
+    //   );
+    //   expect(contractBalance).toEqual(666);
 
-      let queryBlock = await neutronChain.queryContract<{
-        block: { received: boolean };
-      }>(contractAddress, {
-        sudo_result_block_before: {},
-      });
-      let queryTrack = await neutronChain.queryContract<{
-        track: { received: boolean };
-      }>(contractAddress, {
-        sudo_result_track_before: {},
-      });
+    //   let queryBlock = await neutronChain.queryContract<{
+    //     block: { received: boolean };
+    //   }>(contractAddress, {
+    //     sudo_result_block_before: {},
+    //   });
+    //   let queryTrack = await neutronChain.queryContract<{
+    //     track: { received: boolean };
+    //   }>(contractAddress, {
+    //     sudo_result_track_before: {},
+    //   });
 
-      expect(queryTrack.track.received).toEqual(false);
-      expect(queryBlock.block.received).toEqual(false);
+    //   expect(queryTrack.track.received).toEqual(false);
+    //   expect(queryBlock.block.received).toEqual(false);
 
-      await msgSetBeforeSendHook(
-        neutronAccount,
-        ownerWallet.address.toString(),
-        newTokenDenom,
-        contractAddress,
-      );
+    //   await msgSetBeforeSendHook(
+    //     neutronAccount,
+    //     ownerWallet.address.toString(),
+    //     newTokenDenom,
+    //     contractAddress,
+    //   );
 
-      const hookAfter = await getBeforeSendHook(
-        neutronChain.sdk.url,
-        newTokenDenom,
-      );
-      expect(hookAfter.contract_addr).toEqual(contractAddress);
+    //   const hookAfter = await getBeforeSendHook(
+    //     neutronChain.sdk.url,
+    //     newTokenDenom,
+    //   );
+    //   expect(hookAfter.contract_addr).toEqual(contractAddress);
 
-      await neutronAccount.msgSend(contractAddress, {
-        amount: '1',
-        denom: newTokenDenom,
-      });
+    //   await neutronAccount.msgSend(contractAddress, {
+    //     amount: '1',
+    //     denom: newTokenDenom,
+    //   });
 
-      const contractBalanceAfter = await neutronChain.queryDenomBalance(
-        contractAddress,
-        newTokenDenom,
-      );
-      expect(contractBalanceAfter).toEqual(667);
+    //   const contractBalanceAfter = await neutronChain.queryDenomBalance(
+    //     contractAddress,
+    //     newTokenDenom,
+    //   );
+    //   expect(contractBalanceAfter).toEqual(667);
 
-      const balanceAfter = await neutronChain.queryDenomBalance(
-        ownerWallet.address.toString(),
-        newTokenDenom,
-      );
-      expect(balanceAfter).toEqual(9333);
+    //   const balanceAfter = await neutronChain.queryDenomBalance(
+    //     ownerWallet.address.toString(),
+    //     newTokenDenom,
+    //   );
+    //   expect(balanceAfter).toEqual(9333);
 
-      queryBlock = await neutronChain.queryContract<{
-        block: { received: boolean };
-      }>(contractAddress, {
-        sudo_result_block_before: {},
-      });
+    //   queryBlock = await neutronChain.queryContract<{
+    //     block: { received: boolean };
+    //   }>(contractAddress, {
+    //     sudo_result_block_before: {},
+    //   });
 
-      queryTrack = await neutronChain.queryContract<{
-        track: { received: boolean };
-      }>(contractAddress, {
-        sudo_result_track_before: {},
-      });
+    //   queryTrack = await neutronChain.queryContract<{
+    //     track: { received: boolean };
+    //   }>(contractAddress, {
+    //     sudo_result_track_before: {},
+    //   });
 
-      expect(queryTrack.track.received).toEqual(true);
-      expect(queryBlock.block.received).toEqual(true);
-    });
+    //   expect(queryTrack.track.received).toEqual(true);
+    //   expect(queryBlock.block.received).toEqual(true);
+    // });
   });
 
   describe('wasmbindings', () => {
@@ -429,38 +430,38 @@ describe('Neutron / Tokenfactory', () => {
       );
       expect(res.admin).toEqual(contractAddress);
     });
+    // TEMP: remove tests for before send hook
+    // test('set_before_send_hook', async () => {
+    //   await neutronAccount.executeContract(
+    //     contractAddress,
+    //     JSON.stringify({
+    //       set_before_send_hook: {
+    //         denom,
+    //         contract_addr: contractAddress,
+    //       },
+    //     }),
+    //   );
+    //   const res = await neutronChain.queryContract<{
+    //     contract_addr: string;
+    //   }>(contractAddress, {
+    //     before_send_hook: {
+    //       denom,
+    //     },
+    //   });
+    //   expect(res.contract_addr).toEqual(contractAddress);
 
-    test('set_before_send_hook', async () => {
-      await neutronAccount.executeContract(
-        contractAddress,
-        JSON.stringify({
-          set_before_send_hook: {
-            denom,
-            contract_addr: contractAddress,
-          },
-        }),
-      );
-      const res = await neutronChain.queryContract<{
-        contract_addr: string;
-      }>(contractAddress, {
-        before_send_hook: {
-          denom,
-        },
-      });
-      expect(res.contract_addr).toEqual(contractAddress);
+    //   await neutronAccount.executeContract(
+    //     contractAddress,
+    //     JSON.stringify({
+    //       set_before_send_hook: {
+    //         denom,
+    //         contract_addr: '',
+    //       },
+    //     }),
+    //   );
 
-      await neutronAccount.executeContract(
-        contractAddress,
-        JSON.stringify({
-          set_before_send_hook: {
-            denom,
-            contract_addr: '',
-          },
-        }),
-      );
-
-      // TODO: check that it actually sets hook by querying tokenfactory module
-    });
+    //   // TODO: check that it actually sets hook by querying tokenfactory module
+    // });
 
     test('force transfer', async () => {
       const randomAccount = 'neutron14640tst2rx45nxg3evqwlzuaestnnhm8es3rtc';

--- a/src/testcases/run_in_band/parameters.test.ts
+++ b/src/testcases/run_in_band/parameters.test.ts
@@ -129,7 +129,7 @@ describe('Neutron / Parameters', () => {
         'Tokenfactory params proposal',
         updateTokenfacoryParamsProposal({
           fee_collector_address: await neutronChain.getNeutronDAOCore(),
-          denom_creation_fee: null,
+          denom_creation_fee: [{ denom: 'untrn', amount: '1' }],
           denom_creation_gas_consume: 100000,
         }),
         '1000',
@@ -156,13 +156,18 @@ describe('Neutron / Parameters', () => {
       test('check if params changed after proposal execution', async () => {
         const paramsAfter = await neutronChain.queryTokenfactoryParams();
 
-        expect(paramsAfter.params.denom_creation_fee).toEqual(
+        expect(paramsAfter.params.denom_creation_fee).not.toEqual(
           paramsBefore.params.denom_creation_fee,
         );
         expect(paramsAfter.params.denom_creation_gas_consume).not.toEqual(
           paramsBefore.params.denom_creation_gas_consume,
         );
-        expect(paramsAfter.params.denom_creation_fee).toHaveLength(0);
+        expect(paramsAfter.params.denom_creation_fee).toEqual([
+          {
+            denom: 'untrn',
+            amount: '1',
+          },
+        ]);
         expect(paramsAfter.params.denom_creation_gas_consume).toEqual('100000');
       });
     });


### PR DESCRIPTION
Changes for: https://github.com/neutron-org/neutron/pull/587

Changes:
- Disable setBeforeSendHook tests. Given the operation overhead of whitelisting, it is unlikely the contracts will be setting BeforeSendHooks.
- Fix parameters used in tests. Fixes to validation on the neutron side have caused the old parameters to fail

